### PR TITLE
Fix tool usage perks not reducing tool usage

### DIFF
--- a/scripts/entity/world/camp/buildings/repair_building.nut
+++ b/scripts/entity/world/camp/buildings/repair_building.nut
@@ -386,7 +386,7 @@ this.repair_building <- this.inherit("scripts/entity/world/camp/camp_building", 
 			{
 				local consumed = needed * modifiers.Consumption;
 				this.m.ToolsUsed += consumed * perkMod;
-				this.World.Assets.addArmorPartsF(consumed * -1.0);
+				this.World.Assets.addArmorPartsF(consumed * perkMod * -1.0);
 			}
 
 			if (r.Item.getRepair() >= r.Item.getRepairMax())


### PR DESCRIPTION
There has been a longstanding bug where the perks "Tool Drawers" and "Spare Tools" did not reduce the tools used when repairing items. There is a bug report on the discord linked here https://discord.com/channels/547043336465154049/1200960488280961124 where multiple people have tested it.
A comment in asset_manager.nut implies this is intentional 
```
// /100 won't work in Squirrel, also should probably be buffed since it only works on the bro's own equipment and only outside of camp
```
The code in repair_building.nut appears to be trying to implement it to work while camping, however.
```
			if (this.World.Assets.isConsumingAssets())
			{
				local consumed = needed * modifiers.Consumption;
				this.m.ToolsUsed += consumed * perkMod;
				this.World.Assets.addArmorPartsF(consumed * -1.0);
			}
```
ToolsUsed is used for the display upon ending camping showing how many tools have been used to make repairs, while the value sent to addArmorPartsF is the actual amount used. If you instead multiply consumed by perkMod again then the values will not quite match, but be very close, likely due to rounding.
```
				this.World.Assets.addArmorPartsF(consumed * perkMod * -1.0);
```
Here is the test I ran prior to any changes
![image](https://github.com/user-attachments/assets/41e650e6-ec6c-4c97-a67e-32735eba6d78)
The result was 89 tools consumed and 900 durability restored .
After making the above change 74 tools were consumed and the weapon's durability was fully restored which is consistent with the 0.81432576 expected tool use value from two instances of each tool use perk.
This fix causes some issues when combined with the repair tent upgrade. 
![image](https://github.com/user-attachments/assets/1aabb39c-945d-41fc-b2b5-5c732f190827)
The tools used modifier should be 0.5455982592 ```(1*0.96*0.96*0.94*0.94*0.67)``` but it's instead approximately 0.41. This is even lower than if two blacksmith background tool usage bonuses were being counted (0.441934589952), but barely. Considering there is nothing using the background bonuses to my knowledge, this appears to be undesirable. Still, it's much closer to the expected values from the tooltips than the current implementation. 
Oh, I forgot that by this loop
```
		foreach( bro in roster )
		{
			local items = bro.getItems().getAllItems();
			local skills = [
				"perk.legend_tools_spares",
				"perk.legend_tools_drawers"
			];

			foreach( s in skills )
			{
				local skill = bro.getSkills().getSkillByID(s);

				if (skill != null)
				{
					perkMod = this.Math.maxf(perkMod - skill.getModifier() * 0.003, 0.5);
				}
			}
		}
```

the modifier should be 3% for tool drawers and 6% for spare tools. 
That would change the expected values 0.81432576>0.83137924 and 0.5455982592>0.5570240908. 
The tooltip is using 4% as the value shown is 0.814326, but I do not know where the code for that is located.

I redid this PR for 19.0.0 instead of development so that if accepted it could be included sooner at the advice of chopeks. 