### PR TITLE
(Active skills) Fix various typos + a few more subjective text improvements

### DIFF
--- a/scripts/skills/actives/legend_alp_nightmare_manifestation_skill.nut
+++ b/scripts/skills/actives/legend_alp_nightmare_manifestation_skill.nut
@@ -94,7 +94,7 @@ this.legend_alp_nightmare_manifestation_skill <- this.inherit("scripts/skills/sk
 		}
 
 		if (!_user.isHiddenToPlayer() && !_targetTile.getEntity().isHiddenToPlayer())
-			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s nightmare becomes REAL!!!");
+			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(_targetTile.getEntity()) + "\'s nightmare becomes real!");
 
 		if (_targetTile.IsVisibleForPlayer || !_user.isHiddenToPlayer())
 			this.Time.scheduleEvent(this.TimeUnit.Virtual, 400, this.onDelayedEffect.bindenv(this), tag);

--- a/scripts/skills/actives/legend_alp_realm_of_shadow_skill.nut
+++ b/scripts/skills/actives/legend_alp_realm_of_shadow_skill.nut
@@ -59,7 +59,7 @@ this.legend_alp_realm_of_shadow_skill <- this.inherit("scripts/skills/skill", {
 		local func = this.onApplyShadowMistEffect;
 		local p = {
 			Type = "shadows",
-			Tooltip = "A pitch black mist resides here, you can feel a bone chilling air emminates from within.",
+			Tooltip = "A pitch black mist lingers here, eminating a bone chilling air from within",
 			IsPositive = true,
 			IsAppliedAtRoundStart = false,
 			IsAppliedAtTurnEnd = true,

--- a/scripts/skills/actives/legend_apothecary_mushrooms_skill.nut
+++ b/scripts/skills/actives/legend_apothecary_mushrooms_skill.nut
@@ -6,7 +6,7 @@ this.legend_apothecary_mushrooms_skill <- this.inherit("scripts/skills/actives/b
 		this.legend_eat_skill.create();
 		this.m.ID = "actives.legend_apothecary_mushrooms";
 		this.m.Name = "Eat or Give Strange Mushrooms";
-		this.m.Description = "Give to an adjacent ally or eat yourself strange mushrooms to enter a state of trance-like state with otherworldy dodging and no sense of pain. May result in sickness. The effect will slowly wear off over 4 turns. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give these strange mushrooms to an adjacent ally, or eat them yourself to enter a state of trance-like state with otherworldy dodging and no sense of pain. May result in sickness. The effect will slowly wear off over 4 turns. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/active_98.png";
 		this.m.IconDisabled = "skills/active_98_sw.png";
 		this.m.Overlay = "active_98";

--- a/scripts/skills/actives/legend_bear_claws_skill.nut
+++ b/scripts/skills/actives/legend_bear_claws_skill.nut
@@ -15,7 +15,7 @@ this.legend_bear_claws_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_bear_claws";
 		this.m.Name = "Bear Claws";
-		this.m.Description = "Very long and sharp claws that can tear flesh across multiple opponents and leave them bleeding";
+		this.m.Description = "Tear into flesh across multiple opponents and leave them bleading with very long, sharp claws.";
 		this.m.KilledString = "Ripped to shreds";
 		this.m.Icon = "skills/active_21.png";
 		this.m.IconDisabled = "skills/active_21_bw.png";

--- a/scripts/skills/actives/legend_call_lightning_skill.nut
+++ b/scripts/skills/actives/legend_call_lightning_skill.nut
@@ -4,7 +4,7 @@ this.legend_call_lightning_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_call_lightning";
 		this.m.Name = "Call Lightning";
-		this.m.Description = "Call down bolts of lightning randomly within four tiles";
+		this.m.Description = "Call down bolts of lightning randomly within four tiles.";
 		this.m.Icon = "skills/storm_square.png";
 		this.m.IconDisabled = "skills/storm_square_bw.png";
 		this.m.Overlay = "coordinated_volleys_square";

--- a/scripts/skills/actives/legend_charge_skill.nut
+++ b/scripts/skills/actives/legend_charge_skill.nut
@@ -4,7 +4,7 @@ this.legend_charge_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_charge";
 		this.m.Name = "Charge";
-		this.m.Description = "Leap into your enemies, stunning them on contact";
+		this.m.Description = "Leap into your enemies, stunning them on contact.";
 		this.m.Icon = "skills/active_52.png";
 		this.m.IconDisabled = "skills/active_52_sw.png";
 		this.m.Overlay = "active_52";

--- a/scripts/skills/actives/legend_choke_skill.nut
+++ b/scripts/skills/actives/legend_choke_skill.nut
@@ -12,7 +12,7 @@ this.legend_choke_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_choke";
 		this.m.Name = "Choke";
-		this.m.Description = "A well-placed attack at the opponent\'s neck. Ignores all armor but is harder to hit with. Hit chance is based on target's fatigue. Damage is based on the difference in fatigue. Deals 50% damage vs grappled or choked enemies. Hit chance is increased against grappled, stunned, netted, dazed, parried or sleeping enemies";
+		this.m.Description = "A well-placed attack at an opponent\'s neck. Ignores all armor but is harder to hit with. Hit chance is based on target's fatigue. Damage is based on the difference in fatigue. Deals 50% damage against grappled or choked enemies. Hit chance is increased against grappled, stunned, netted, dazed, parried or sleeping enemies.";
 		this.m.KilledString = "Choked";
 		this.m.Icon = "skills/choke_square.png";
 		this.m.IconDisabled = "skills/choke_square_bw.png";

--- a/scripts/skills/actives/legend_climb_skill.nut
+++ b/scripts/skills/actives/legend_climb_skill.nut
@@ -4,7 +4,7 @@ this.legend_climb_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_climb";
 		this.m.Name = "Climb";
-		this.m.Description = "Allows you to move up or down levels, does not trigger attacks of opportunity. Can not be used on flat ground";
+		this.m.Description = "Allows you to move up or down levels. Does not trigger attacks of opportunity. Can not be used on flat ground.";
 		this.m.Icon = "skills/climb_square.png";
 		this.m.IconDisabled = "skills/climb_square_bw.png";
 		this.m.Overlay = "climb_square";

--- a/scripts/skills/actives/legend_coordinated_volleys_skill.nut
+++ b/scripts/skills/actives/legend_coordinated_volleys_skill.nut
@@ -4,7 +4,7 @@ this.legend_coordinated_volleys_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_coordinated_volleys";
 		this.m.Name = "Coordinated Volleys";
-		this.m.Description = "Time and call the shots for archers, increasing their chance to hit";
+		this.m.Description = "Time and call the shots for archers, increasing their chance to hit.";
 		this.m.Icon = "skills/coordinated_volleys_square.png";
 		this.m.IconDisabled = "skills/coordinated_volleys_square_bw.png";
 		this.m.Overlay = "coordinated_volleys_square";

--- a/scripts/skills/actives/legend_curseofyears_skill.nut
+++ b/scripts/skills/actives/legend_curseofyears_skill.nut
@@ -6,7 +6,7 @@ this.legend_curseofyears_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_curseofyears";
 		this.m.Name = "Decrepify";
-		this.m.Description = "This curse gives the victim a glimpse of his own mortality, briefly aging the victim. Imagining itself with an infirm body of advanced age, the afflicted believes it is no longer capable of youthful exertions. ";
+		this.m.Description = "This curse gives the victim a glimpse of their own mortality, briefly aging them. Imagining itself with an infirm body of advanced age, the afflicted believes it is no longer capable of youthful exertions.";
 		this.m.Icon = "skills/active_117.png";
 		this.m.IconDisabled = "skills/active_117_sw.png";
 		this.m.Overlay = "active_117";

--- a/scripts/skills/actives/legend_danger_pay_skill.nut
+++ b/scripts/skills/actives/legend_danger_pay_skill.nut
@@ -9,7 +9,7 @@ this.legend_danger_pay_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_danger_pay";
 		this.m.Name = "Danger Pay";
-		this.m.Description = "Pay a unit " + this.m.Multiplier + "x their daily wage to set their morale to Confident and granting them the buff 'Motivated' for three turns.";
+		this.m.Description = "Pay a unit " + this.m.Multiplier + "x their daily wage to set their morale to Confident and grant them the buff 'Motivated' for three turns.";
 		this.m.Icon = "skills/coins_square.png";
 		this.m.IconDisabled = "skills/coins_square_bw.png";
 		this.m.Overlay = "active_41";

--- a/scripts/skills/actives/legend_darkflight_skill.nut
+++ b/scripts/skills/actives/legend_darkflight_skill.nut
@@ -4,7 +4,7 @@ this.legend_darkflight_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_darkflight";
 		this.m.Name = "Darkflight";
-		this.m.Description = "Disapparate from your current location and reappear on the other side of the battlefield";
+		this.m.Description = "Disapparate from your current location and reappear on the other side of the battlefield.";
 		this.m.Icon = "skills/darkflight.png";
 		this.m.IconDisabled = "skills/darkflight_bw.png";
 		this.m.Overlay = "active_28";

--- a/scripts/skills/actives/legend_daze_skill.nut
+++ b/scripts/skills/actives/legend_daze_skill.nut
@@ -4,7 +4,7 @@ this.legend_daze_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_daze";
 		this.m.Name = "Daze";
-		this.m.Description = "Assault the senses of your target with a flurry of colorful sparks, whirs, and pops. Such an astonishing display is sure to leave anyone too bewildered to fight effectively. Does no damage";
+		this.m.Description = "Assault the senses of your target with a flurry of colorful sparks, whirs, and pops. Such an astonishing display is sure to leave anyone too bewildered to fight effectively. Does no damage.";
 		this.m.KilledString = "Dazed";
 		this.m.Icon = "skills/daze_square.png";
 		this.m.IconDisabled = "skills/daze_square_bw.png";

--- a/scripts/skills/actives/legend_dog_handling_skill.nut
+++ b/scripts/skills/actives/legend_dog_handling_skill.nut
@@ -6,7 +6,7 @@ this.legend_dog_handling_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_dog_handling";
 		this.m.Name = "Dog Handling";
-		this.m.Description = "Use food to convince an enemy dog to flee the battle";
+		this.m.Description = "Use food to convince an enemy dog to flee the battle.";
 		this.m.Icon = "skills/skill_dog_handling.png";
 		this.m.IconDisabled = "skills/skill_dog_handling_bw.png";
 		this.m.Overlay = "dog_circle";

--- a/scripts/skills/actives/legend_dog_master_skill.nut
+++ b/scripts/skills/actives/legend_dog_master_skill.nut
@@ -6,7 +6,7 @@ this.legend_dog_master_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_dog_master";
 		this.m.Name = "Dog Master";
-		this.m.Description = "Use food to convince an enemy dog to flee the battle";
+		this.m.Description = "Use food to convince an enemy dog to flee the battle.";
 		this.m.Icon = "skills/skill_dog_handling.png";
 		this.m.IconDisabled = "skills/skill_dog_handling_bw.png";
 		this.m.Overlay = "dog_circle";

--- a/scripts/skills/actives/legend_donkey_kick_skill.nut
+++ b/scripts/skills/actives/legend_donkey_kick_skill.nut
@@ -4,7 +4,7 @@ this.legend_donkey_kick_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_donkey_kick";
 		this.m.Name = "Donkey Kick";
-		this.m.Description = "The main attack of a donkey, more for defense than attack. Maximum damage is the average of your hitpoints and initiative minus 90";
+		this.m.Description = "The main attack of a donkey, more for defense than attack. Maximum damage is the average of your hitpoints and initiative minus 90.";
 		this.m.KilledString = "Kicked to death";
 		this.m.Icon = "skills/horse_kick.png";
 		this.m.IconDisabled = "skills/horse_kick_bw.png";

--- a/scripts/skills/actives/legend_drain_skill.nut
+++ b/scripts/skills/actives/legend_drain_skill.nut
@@ -4,7 +4,7 @@ this.legend_drain_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_drain";
 		this.m.Name = "Drain Life";
-		this.m.Description = "Pull the essence from your foe, and draw it into yourself ";
+		this.m.Description = "Pull the essence from your foe, and draw it into yourself.";
 		this.m.KilledString = "Drained";
 		this.m.Icon = "skills/blooddrop_square.png";
 		this.m.IconDisabled = "skills/blooddrop_square_bw.png";

--- a/scripts/skills/actives/legend_drink_beer_skill.nut
+++ b/scripts/skills/actives/legend_drink_beer_skill.nut
@@ -6,7 +6,7 @@ this.legend_drink_beer_skill <- this.inherit("scripts/skills/actives/base/legend
 		this.legend_drink_alcohol_skill.create();
 		this.m.ID = "actives.legend_drink_beer";
 		this.m.Name = "Drink or Give Beer";
-		this.m.Description = "Give to an adjacent ally or drink beer to get buzzed, will get you drunk if already buzzed, and sick if you're already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or drink beer to get buzzed, or drunk if already buzzed, or sick if already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/beer_square.png";
 		this.m.IconDisabled = "skills/beer_square_bw.png";
 		this.m.Overlay = "active_144";

--- a/scripts/skills/actives/legend_drink_liquor_skill.nut
+++ b/scripts/skills/actives/legend_drink_liquor_skill.nut
@@ -6,7 +6,7 @@ this.legend_drink_liquor_skill <- this.inherit("scripts/skills/actives/base/lege
 		this.legend_drink_alcohol_skill.create();
 		this.m.ID = "actives.legend_drink_liquor";
 		this.m.Name = "Drink or Give Liquor";
-		this.m.Description = "Give to an adjacent ally or drink liquor to get warmed, will get you drunk if already warmed, and sick if you're already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or drink liquor to get warmed, or drunk if already warmed, or sick if already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/mead_square.png";
 		this.m.IconDisabled = "skills/mead_square_bw.png";
 		this.m.Overlay = "active_144";

--- a/scripts/skills/actives/legend_drink_mead_skill.nut
+++ b/scripts/skills/actives/legend_drink_mead_skill.nut
@@ -6,7 +6,7 @@ this.legend_drink_mead_skill <- this.inherit("scripts/skills/actives/base/legend
 		this.legend_drink_alcohol_skill.create();
 		this.m.ID = "actives.legend_drink_mead";
 		this.m.Name = "Drink or Give Mead";
-		this.m.Description = "Give to an adjacent ally or drink mead to get warmed, will get you drunk if already warmed, and sick if you're already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or drink mead to get warmed, or drunk if already warmed, or sick if already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/mead_square.png";
 		this.m.IconDisabled = "skills/mead_square_bw.png";
 		this.m.Overlay = "active_144";

--- a/scripts/skills/actives/legend_drink_therianthropy_potion_skill.nut
+++ b/scripts/skills/actives/legend_drink_therianthropy_potion_skill.nut
@@ -5,7 +5,7 @@ this.legend_drink_therianthropy_potion_skill <- this.inherit("scripts/skills/act
 		this.legend_drink_potion_skill.create();
 		this.m.ID = "actives.legend_drink_therianthropy_potion";
 		this.m.Name = "Drink or Give Therianthropic Potion";
-		this.m.Description = "Give to an adjacent ally or drink yourself a horrible concoction of poison taken from the bodies of beasts to destroys your own humanity. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or drink yourself a horrible concoction of poison taken from the bodies of beasts to destroy your own humanity. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/active_143.png";
 		this.m.IconDisabled = "skills/active_143_sw.png";
 		this.m.Overlay = "active_143";

--- a/scripts/skills/actives/legend_drink_wine_skill.nut
+++ b/scripts/skills/actives/legend_drink_wine_skill.nut
@@ -6,7 +6,7 @@ this.legend_drink_wine_skill <- this.inherit("scripts/skills/actives/base/legend
 		this.legend_drink_alcohol_skill.create();
 		this.m.ID = "actives.legend_drink_wine";
 		this.m.Name = "Drink or Give Wine";
-		this.m.Description = "Give to an adjacent ally or drink wine to get tipsy, will get you drunk if already tipsy, and sick if you're already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or drink wine to get tipsy, or drunk if already tipsy, or sick if already drunk. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/wine_square.png";
 		this.m.IconDisabled = "skills/wine_square_bw.png";
 		this.m.Overlay = "active_144";

--- a/scripts/skills/actives/legend_eat_pie_skill.nut
+++ b/scripts/skills/actives/legend_eat_pie_skill.nut
@@ -6,7 +6,7 @@ this.legend_eat_pie_skill <- this.inherit("scripts/skills/actives/base/legend_ea
 		this.legend_eat_skill.create();
 		this.m.ID = "actives.legend_eat_pie";
 		this.m.Name = "Eat or Give Pie";
-		this.m.Description = "Give to an adjacent ally or eat yourself a pie that slowly heals Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or eat yourself a pie that slowly recovers hitpoints. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/pie_square.png";
 		this.m.IconDisabled = "skills/pie_square_bw.png";
 	}
@@ -32,8 +32,8 @@ this.legend_eat_pie_skill <- this.inherit("scripts/skills/actives/base/legend_ea
 			{
 				id = 11,
 				type = "text",
-				icon = "ui/icons/hitpoints.png",
-				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+1[/color] Health per turn for 10 turns"
+				icon = "ui/icons/health.png",
+				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+1[/color] Hitpoints per turn for 10 turns"
 			},
 			{
 				id = 12,

--- a/scripts/skills/actives/legend_eat_porridge_skill.nut
+++ b/scripts/skills/actives/legend_eat_porridge_skill.nut
@@ -6,7 +6,7 @@ this.legend_eat_porridge_skill <- this.inherit("scripts/skills/actives/base/lege
 		this.legend_eat_skill.create();
 		this.m.ID = "actives.legend_eat_porridge";
 		this.m.Name = "Eat or Give Porridge";
-		this.m.Description = "Give to an adjacent ally or eat yourself a porridge that slowly heals Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or eat yourself a porridge that slowly recovers hitpoints. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/porridge_square.png";
 		this.m.IconDisabled = "skills/porridge_square_bw.png";
 	}
@@ -32,8 +32,8 @@ this.legend_eat_porridge_skill <- this.inherit("scripts/skills/actives/base/lege
 			{
 				id = 11,
 				type = "text",
-				icon = "ui/icons/initiative.png",
-				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+10[/color] Health per turn for 15 turns"
+				icon = "ui/icons/health.png",
+				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+10[/color] Hitpoints per turn for 15 turns"
 			}
 		];
 

--- a/scripts/skills/actives/legend_eat_pudding_skill.nut
+++ b/scripts/skills/actives/legend_eat_pudding_skill.nut
@@ -6,7 +6,7 @@ this.legend_eat_pudding_skill <- this.inherit("scripts/skills/actives/base/legen
 		this.legend_eat_skill.create();
 		this.m.ID = "actives.legend_eat_pudding";
 		this.m.Name = "Eat or Give Pudding";
-		this.m.Description = "Give to an adjacent ally or eat yourself a pudding that slowly heals Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or eat yourself a pudding that slowly recovers hitpoints. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/pudding_square.png";
 		this.m.IconDisabled = "skills/pudding_square_bw.png";
 	}
@@ -33,7 +33,7 @@ this.legend_eat_pudding_skill <- this.inherit("scripts/skills/actives/base/legen
 				id = 11,
 				type = "text",
 				icon = "ui/icons/health.png",
-				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+5[/color] Health per turn for 10 turns"
+				text = "[color=" + this.Const.UI.Color.PositiveValue + "]+5[/color] Hitpoints per turn for 10 turns"
 			},
 			{
 				id = 12,

--- a/scripts/skills/actives/legend_eat_rations_skill.nut
+++ b/scripts/skills/actives/legend_eat_rations_skill.nut
@@ -6,7 +6,7 @@ this.legend_eat_rations_skill <- this.inherit("scripts/skills/actives/base/legen
 		this.legend_eat_skill.create();
 		this.m.ID = "actives.legend_eat_rations";
 		this.m.Name = "Eat or Give Food";
-		this.m.Description = "Give to an adjacent ally or eat food that slowly heals. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
+		this.m.Description = "Give to an adjacent ally or eat food that slowly recovers hitpoints. Can not be used while engaged in melee, and anyone receiving the item needs to have a free bag slot.";
 		this.m.Icon = "skills/rations_square.png";
 		this.m.IconDisabled = "skills/rations_square_bw.png";
 	}
@@ -52,7 +52,7 @@ this.legend_eat_rations_skill <- this.inherit("scripts/skills/actives/base/legen
 				id = 11,
 				type = "text",
 				icon = "ui/icons/health.png",
-				text = "On self, will restore [color=" + this.Const.UI.Color.PositiveValue + "]+" + rate + "[/color] Health per turn for ten turns"
+				text = "On self, will restore [color=" + this.Const.UI.Color.PositiveValue + "]+" + rate + "[/color] Hitpoints per turn for ten turns"
 			},
 			{
 				id = 11,

--- a/scripts/skills/actives/legend_entice_skill.nut
+++ b/scripts/skills/actives/legend_entice_skill.nut
@@ -4,7 +4,7 @@ this.legend_entice_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_entice";
 		this.m.Name = "Entice";
-		this.m.Description = "With a trick of the light, captivate your target in such a way that they can\'t help but approach you. ";
+		this.m.Description = "With a trick of the light, captivate your target in such a way that they can\'t help but approach you.";
 		this.m.Icon = "skills/entice.png";
 		this.m.IconDisabled = "skills/entice_bw.png";
 		this.m.Overlay = "entice";

--- a/scripts/skills/actives/legend_evasion_skill.nut
+++ b/scripts/skills/actives/legend_evasion_skill.nut
@@ -6,7 +6,7 @@ this.legend_evasion_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_evasion";
 		this.m.Name = "Evasion";
-		this.m.Description = "Prepares the character safely through any Zone of Control next turn without incurring any free attacks.";
+		this.m.Description = "Prepares the character to move safely through any Zone of Control next turn without incurring any free attacks.";
 		this.m.Icon = "skills/evasion.png";
 		this.m.IconDisabled = "skills/evasion_bw.png";
 		this.m.Overlay = "evasion";

--- a/scripts/skills/actives/legend_field_triage_skill.nut
+++ b/scripts/skills/actives/legend_field_triage_skill.nut
@@ -51,7 +51,7 @@ this.legend_field_triage_skill <- this.inherit("scripts/skills/skill", {
 			id = 8,
 			type = "text",
 			icon = "ui/icons/health.png",
-			text = "You can heal up to [color=" + this.Const.UI.Color.PositiveValue +"]" + this.Math.floor(hp) +  "[/color] hitpoints."
+			text = "You can heal up to [color=" + this.Const.UI.Color.PositiveValue +"]" + this.Math.floor(hp) +  "[/color] Hitpoints."
 		});
 		return ret;
 	}

--- a/scripts/skills/actives/legend_field_triage_skill.nut
+++ b/scripts/skills/actives/legend_field_triage_skill.nut
@@ -7,7 +7,7 @@ this.legend_field_triage_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_field_triage";
 		this.m.Name = "Field Triage";
-		this.m.Description = "Heal a unit, costs 1 medicine for every 2 health. Heals up to 20 health per use";
+		this.m.Description = "Heal a unit at a rate of 1 medicine for every 2 hitpoints. Heals up to 20 hitpoints per use.";
 		this.m.Icon = "skills/triage_square.png";
 		this.m.IconDisabled = "skills/triage_square_bw.png";
 		this.m.Overlay = "active_41";

--- a/scripts/skills/actives/legend_firefield_skill.nut
+++ b/scripts/skills/actives/legend_firefield_skill.nut
@@ -6,7 +6,7 @@ this.legend_firefield_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_firefield";
 		this.m.Name = "Fire Pot";
-		this.m.Description = "Throw a pot releasing a field of fire that burns all beings";
+		this.m.Description = "Throw a pot releasing a field of fire that burns all beings.";
 		this.m.Icon = "skills/fire_square.png";
 		this.m.IconDisabled = "skills/fire_square_bw.png";
 		this.m.Overlay = "fire_circle";

--- a/scripts/skills/actives/legend_flogging_skill.nut
+++ b/scripts/skills/actives/legend_flogging_skill.nut
@@ -4,7 +4,7 @@ this.legend_flogging_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_flogging";
 		this.m.Name = "Flogging";
-		this.m.Description = "Whip the flesh of someone nearby to inflict a slow bleed ";
+		this.m.Description = "Whip the flesh of someone nearby to inflict a slow bleed.";
 		this.m.KilledString = "Flogged";
 		this.m.Icon = "skills/bleed_square.png";
 		this.m.IconDisabled = "skills/bleed_square_bw.png";

--- a/scripts/skills/actives/legend_grapple_skill.nut
+++ b/scripts/skills/actives/legend_grapple_skill.nut
@@ -7,7 +7,7 @@ this.legend_grapple_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_grapple";
 		this.m.Name = "Grapple";
-		this.m.Description = "Grab hold and restrain a target, reducing their melee defense by 12 and initiative by 30% for 2 turns. A particularly lucky or skilled maneuver may disarm the opponent. One hand must be free to use.";
+		this.m.Description = "Grab, hold, and restrain a target, reducing their melee defense by 12 and initiative by 30% for 2 turns. A particularly lucky or skilled maneuver may disarm the opponent. One hand must be free to use.";
 		this.m.Icon = "skills/grapple_square.png";
 		this.m.IconDisabled = "skills/grapple_square_bw.png";
 		this.m.Overlay = "active_grapple";

--- a/scripts/skills/actives/legend_guide_steps_skill.nut
+++ b/scripts/skills/actives/legend_guide_steps_skill.nut
@@ -4,7 +4,7 @@ this.legend_guide_steps_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_guide_steps";
 		this.m.Name = "Guide steps";
-		this.m.Description = "Point out dips and obstacles in the landscape, increasing movement for your troops";
+		this.m.Description = "Point out dips and obstacles in the landscape, increasing movement for your troops.";
 		this.m.Icon = "skills/guided_steps_square.png";
 		this.m.IconDisabled = "skills/guided_steps_square_bw.png";
 		this.m.Overlay = "guided_steps_square";

--- a/scripts/skills/actives/legend_hex_skill.nut
+++ b/scripts/skills/actives/legend_hex_skill.nut
@@ -6,7 +6,7 @@ this.legend_hex_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_hex";
 		this.m.Name = "Hex";
-		this.m.Description = "You tie your soul to your enemy, your pain becomes their pain";
+		this.m.Description = "Tie your soul to your enemy, forcing them to feel the same pain you do.";
 		this.m.Icon = "skills/hex_square.png";
 		this.m.IconDisabled = "skills/hex_square_bw.png";
 		this.m.Overlay = "active_119";

--- a/scripts/skills/actives/legend_holyflame_skill.nut
+++ b/scripts/skills/actives/legend_holyflame_skill.nut
@@ -4,7 +4,7 @@ this.legend_holyflame_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_holyflame";
 		this.m.Name = "Holy Flame";
-		this.m.Description = "Bless an area, the holy shall be sanctified when entering, the damned shall be consecrated.";
+		this.m.Description = "Bless an area. The holy shall be sanctified when entering, the damned shall be consecrated.";
 		this.m.Icon = "skills/holybluefire_square.png";
 		this.m.IconDisabled = "skills/holyfire_square_bw.png";
 		this.m.Overlay = "holybluefire_square";

--- a/scripts/skills/actives/legend_horrific_scream.nut
+++ b/scripts/skills/actives/legend_horrific_scream.nut
@@ -4,7 +4,7 @@ this.legend_horrific_scream <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_horrific_scream";
 		this.m.Name = "Horrific Scream";
-		this.m.Description = "Blare out a piercing, unworldly sound that is more than likely to distress anyone unfortunate enough to hear it within 4 tiles. Uses ranged skill";
+		this.m.Description = "Blare out a piercing, unworldly sound that is more than likely to distress anyone unfortunate enough to hear it within 4 tiles. Uses ranged skill.";
 		this.m.Icon = "skills/horrify56.png";
 		this.m.IconDisabled = "skills/horrify56_bw.png";
 		this.m.Overlay = "active_41";

--- a/scripts/skills/actives/legend_horse_charge_skill.nut
+++ b/scripts/skills/actives/legend_horse_charge_skill.nut
@@ -4,7 +4,7 @@ this.legend_horse_charge_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_horse_charge";
 		this.m.Name = "Horse Charge";
-		this.m.Description = "Push your mount forward with speed, ending in an impact that stuns an enemy";
+		this.m.Description = "Push your mount forward with speed, ending in an impact that stuns an enemy.";
 		this.m.Icon = "skills/horse_charge.png";
 		this.m.IconDisabled = "skills/horse_charge_bw.png";
 		this.m.Overlay = "horse_charge";

--- a/scripts/skills/actives/legend_horse_kick_skill.nut
+++ b/scripts/skills/actives/legend_horse_kick_skill.nut
@@ -11,7 +11,7 @@ this.legend_horse_kick_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_horse_kick";
 		this.m.Name = "Horse Kick";
-		this.m.Description = "The main attack of a horse, more for defense than attack. Maximum damage is the average of your hitpoints and initiative minus 90";
+		this.m.Description = "The main attack of a horse, more for defense than attack. Maximum damage is the average of your hitpoints and initiative minus 90.";
 		this.m.KilledString = "Kicked to death";
 		this.m.Icon = "skills/horse_kick.png";
 		this.m.IconDisabled = "skills/horse_kick_bw.png";

--- a/scripts/skills/actives/legend_horse_pirouette_skill.nut
+++ b/scripts/skills/actives/legend_horse_pirouette_skill.nut
@@ -4,7 +4,7 @@ this.legend_horse_pirouette_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_horse_pirouette";
 		this.m.Name = "Pirouette";
-		this.m.Description = "Learning to turn quickly allows quick changes in direction required to leave a Zone of Control without triggering free attacks.";
+		this.m.Description = "Learning to turn quickly allows the rapid changes in direction required to leave a Zone of Control without triggering free attacks.";
 		this.m.Icon = "skills/horse_pirouette.png";
 		this.m.IconDisabled = "skills/horse_pirouette_bw.png";
 		this.m.Overlay = "horse_pirouette";

--- a/scripts/skills/actives/legend_kick_skill.nut
+++ b/scripts/skills/actives/legend_kick_skill.nut
@@ -6,7 +6,7 @@ this.legend_kick_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_kick";
 		this.m.Name = "Kick";
-		this.m.Description = "Kick a target to break their balance. Targets hit will receive fatigue, get staggered, and a chance of daze. Shieldwall, Spearwall, Return Favor, and Riposte will be canceled for a target that is successfully hit.";
+		this.m.Description = "Kick a target to break their balance. The blow will inflict additional fatigue, stagger the target, and has a chance to inflict daze as well. Shieldwall, Spearwall, Return Favor, and Riposte will be canceled for a target that is successfully hit.";
 		this.m.Icon = "skills/kick_square.png";
 		this.m.IconDisabled = "skills/kick_square_bw.png";
 		this.m.Overlay = "active_kick";

--- a/scripts/skills/actives/legend_leap_skill.nut
+++ b/scripts/skills/actives/legend_leap_skill.nut
@@ -4,7 +4,7 @@ this.legend_leap_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_leap";
 		this.m.Name = "Leap";
-		this.m.Description = "Learning to jump extended distances allows escape from usually impossible situations. Fatigue cost is 15 plus the weight of your armor. Range can be increased with the Backflip perk, and by taking Staff Mastery and wielding staff.";
+		this.m.Description = "Learning to jump extended distances allows escape from usually impossible situations. Fatigue cost is 15 plus the weight of your armor. Range can be increased with the Backflip perk, and by taking Staff Mastery and wielding a staff.";
 		this.m.Icon = "skills/leap_square.png";
 		this.m.IconDisabled = "skills/leap_square_bw.png";
 		this.m.Overlay = "horse_pirouette";

--- a/scripts/skills/actives/legend_levitate_person_skill.nut
+++ b/scripts/skills/actives/legend_levitate_person_skill.nut
@@ -4,7 +4,7 @@ this.legend_levitate_person_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_levitate_person";
 		this.m.Name = "Levitate Person";
-		this.m.Description = "Levitate someone off the ground, granting them the ability to move freely across all terrain";
+		this.m.Description = "Levitate someone off the ground, granting them the ability to move freely across all terrain.";
 		this.m.KilledString = "Levitated";
 		this.m.Icon = "skills/levitate_square.png";
 		this.m.IconDisabled = "skills/levitate_square_bw.png";

--- a/scripts/skills/actives/legend_magic_circle_of_protection_skill.nut
+++ b/scripts/skills/actives/legend_magic_circle_of_protection_skill.nut
@@ -10,7 +10,7 @@ this.legend_magic_circle_of_protection_skill <- this.inherit("scripts/skills/act
 	{
 		this.m.ID="actives.legend_magic_circle_of_protection";
 		this.m.Name = "Magic Circle of Protection";
-		this.m.Description = "A magic circle that protects all allies within at casting. Leaving the circle breaks the protection.";
+		this.m.Description = "A magic circle that protects all allies within when cast. Leaving the circle breaks the protection.";
 		this.m.KilledString = "Magic Circled";
 		this.m.Icon = "skills/mage_legend_magic_circle_of_protection_square.png";
 		this.m.IconDisabled = "skills/mage_legend_magic_circle_of_protection_square_bw.png";

--- a/scripts/skills/actives/legend_miasma_skill.nut
+++ b/scripts/skills/actives/legend_miasma_skill.nut
@@ -4,7 +4,7 @@ this.legend_miasma_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_miasma";
 		this.m.Name = "Miasma";
-		this.m.Description = "Release a cloud of noxious gasses that effects living beings";
+		this.m.Description = "Release a cloud of noxious gasses that affect living beings.";
 		this.m.Icon = "skills/miasma_square.png";
 		this.m.IconDisabled = "skills/miasma_square_bw.png";
 		this.m.Overlay = "miasma_square";

--- a/scripts/skills/actives/legend_nightvision_skill.nut
+++ b/scripts/skills/actives/legend_nightvision_skill.nut
@@ -4,7 +4,7 @@ this.legend_nightvision_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_nightvision";
 		this.m.Name = "Nightvision";
-		this.m.Description = "Use your superior vision to pick out enemies in the dark and point them out to your mercenaries";
+		this.m.Description = "Use your superior vision to pick out enemies in the dark and point them out to your mercenaries.";
 		this.m.Icon = "skills/nightvision_square.png";
 		this.m.IconDisabled = "skills/nightvision_square_bw.png";
 		this.m.Overlay = "nightvision_square";

--- a/scripts/skills/actives/legend_piercing_bolt_skill.nut
+++ b/scripts/skills/actives/legend_piercing_bolt_skill.nut
@@ -8,7 +8,7 @@ this.legend_piercing_bolt_skill <- ::inherit("scripts/skills/actives/shoot_bolt"
 		this.shoot_bolt.create();
 		m.ID = "actives.legend_piercing_bolt";
 		m.Name = "Piercing Bolt";
-		m.Description = "A shot with so much force that it passes straight through one enemy to the enemy behind them";
+		m.Description = "A shot with so much force that it passes straight through the target to whoever is behind them.";
 		m.KilledString = "Pierced";
 		m.Icon = "skills/PiercingBoltSkill.png";
 		m.IconDisabled = "skills/PiercingBoltSkill_bw.png";

--- a/scripts/skills/actives/legend_piercing_shot_skill.nut
+++ b/scripts/skills/actives/legend_piercing_shot_skill.nut
@@ -8,7 +8,7 @@ this.legend_piercing_shot_skill <- ::inherit("scripts/skills/actives/aimed_shot"
 		this.aimed_shot.create();
 		m.ID = "actives.legend_piercing_shot";
 		m.Name = "Piercing Shot";
-		m.Description = "A shot with so much force that it passes straight through one enemy to the enemy behind them";
+		m.Description = "A shot with so much force that it passes straight through the target to whoever is behind them.";
 		m.KilledString = "Pierced";
 		m.Icon = "skills/PiercingBoltSkill.png";
 		m.IconDisabled = "skills/PiercingBoltSkill_bw.png";

--- a/scripts/skills/actives/legend_prepare_bleed_skill.nut
+++ b/scripts/skills/actives/legend_prepare_bleed_skill.nut
@@ -11,7 +11,7 @@ this.legend_prepare_bleed_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_prepare_bleed";
 		this.m.Name = "Prepare to Bleed";
-		this.m.Description = "Evaluate your enemy, preparing your next attack to leave them bleeding";
+		this.m.Description = "Evaluate your enemy, preparing your next attack to leave them bleeding.";
 		this.m.Icon = "skills/bleed_square.png";
 		this.m.IconDisabled = "skills/bleed_square_bw.png";
 		this.m.Overlay = "status_effect_01";

--- a/scripts/skills/actives/legend_push_skill.nut
+++ b/scripts/skills/actives/legend_push_skill.nut
@@ -4,7 +4,7 @@ this.legend_push_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_push";
 		this.m.Name = "Revolt";
-		this.m.Description = "Concoct a mixture of smells so fetid and noxious, you force your target to retreat just so they can breathe. Targets hit will receive fatigue and may take damage if they are pushed down several levels of height. Shieldwall, Spearwall and Riposte will be canceled for a target that is successfully knocked back. A rooted target can not be knocked back. Uses Ranged Skill";
+		this.m.Description = "Concoct a mixture of smells so fetid and noxious, you force your target to retreat just so they can breathe. Targets hit will receive fatigue and may take damage if they are pushed down several levels of height. Shieldwall, Spearwall and Riposte will be canceled for a target that is successfully knocked back. A rooted target can not be knocked back. Uses Ranged Skill.";
 		this.m.Icon = "skills/revolt_square.png";
 		this.m.IconDisabled = "skills/revolt_square_bw.png";
 		this.m.Overlay = "revolt_square";

--- a/scripts/skills/actives/legend_rat_bite_skill.nut
+++ b/scripts/skills/actives/legend_rat_bite_skill.nut
@@ -4,7 +4,7 @@ this.legend_rat_bite_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_rat_bite";
 		this.m.Name = "Rat Bite";
-		this.m.Description = "A vicious bite with a 15% increased chance to hit the head and 100% chance to infect";
+		this.m.Description = "A vicious bite with a 15% increased chance to hit the head and 100% chance to infect.";
 		this.m.KilledString = "Gnawed";
 		this.m.Icon = "skills/rat_bite.png";
 		this.m.IconDisabled = "skills/rat_bite_bw.png";

--- a/scripts/skills/actives/legend_rat_claws_skill.nut
+++ b/scripts/skills/actives/legend_rat_claws_skill.nut
@@ -4,7 +4,7 @@ this.legend_rat_claws_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_rat_claws";
 		this.m.Name = "Rat Claws";
-		this.m.Description = "Short sharp claws that can tear flesh.";
+		this.m.Description = "Tear into flesh with short, sharp claws.";
 		this.m.Icon = "skills/active_21.png";
 		this.m.IconDisabled = "skills/active_21_bw.png";
 		this.m.Overlay = "active_21";

--- a/scripts/skills/actives/legend_redback_puncture_skill.nut
+++ b/scripts/skills/actives/legend_redback_puncture_skill.nut
@@ -4,7 +4,7 @@ this.legend_redback_puncture_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_redback_puncture";
 		this.m.Name = "Redback Poison Puncture";
-		this.m.Description = "A well-placed attack at the opponent armor\'s weakspots with redback poison. Ignores all armor and injects the target with poison but is harder to hit with and can not land critical hits for additional damage, nor inflict additional damage with double grip. Poison does not work on undead and you must deal enough damage for the poison to enter the system";
+		this.m.Description = "A well-placed attack at the opponent armor\'s weakspots with redback poison. Ignores all armor and injects the target with poison but is harder to hit with and can not land critical hits for additional damage, nor inflict additional damage with double grip. Poison does not work on undead and you must deal enough damage for the poison to enter the system.";
 		this.m.KilledString = "Punctured";
 		this.m.Icon = "skills/active_27.png";
 		this.m.IconDisabled = "skills/active_27_sw.png";

--- a/scripts/skills/actives/legend_relax_skill.nut
+++ b/scripts/skills/actives/legend_relax_skill.nut
@@ -4,7 +4,7 @@ this.legend_relax_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_relax";
 		this.m.Name = "Relax";
-		this.m.Description = "You imbue an ally with calm and focus, reducing their fatigue";
+		this.m.Description = "You imbue an ally with calm and focus, reducing their fatigue.";
 		this.m.Icon = "skills/relax_square.png";
 		this.m.IconDisabled = "skills/relax_square_bw.png";
 		this.m.Overlay = "relax_square";

--- a/scripts/skills/actives/legend_revolt_skill.nut
+++ b/scripts/skills/actives/legend_revolt_skill.nut
@@ -4,7 +4,7 @@ this.legend_revolt_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_revolt";
 		this.m.Name = "Revolt";
-		this.m.Description = "Concoct a mixture of smells so fetid and noxious, you force your target to retreat just so they can breathe. Targets hit will receive fatigue and may take damage if they are pushed down several levels of height. Shieldwall, Spearwall and Riposte will be canceled for a target that is successfully knocked back. A rooted target can not be knocked back. Uses Ranged Skill";
+		this.m.Description = "Concoct a mixture of smells so fetid and noxious, you force your target to retreat just so they can breathe. Targets hit will receive fatigue and may take damage if they are pushed down several levels of height. Shieldwall, Spearwall and Riposte will be canceled for a target that is successfully knocked back. A rooted target can not be knocked back. Uses Ranged Skill.";
 		this.m.Icon = "skills/revolt_square.png";
 		this.m.IconDisabled = "skills/revolt_square_bw.png";
 		this.m.Overlay = "revolt_square";

--- a/scripts/skills/actives/legend_root_skill.nut
+++ b/scripts/skills/actives/legend_root_skill.nut
@@ -4,7 +4,7 @@ this.legend_root_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_root";
 		this.m.Name = "Root";
-		this.m.Description = "Unleash roots from the ground to ensnare your foes. Fatigue and AP costs reduced while raining and with staff mastery. ";
+		this.m.Description = "Unleash roots from the ground to ensnare your foes. Fatigue and AP costs reduced while raining and with staff mastery.";
 		this.m.Icon = "skills/roots_square.png";
 		this.m.IconDisabled = "skills/roots_square_bw.png";
 		this.m.Overlay = "active_70";

--- a/scripts/skills/actives/legend_rust_skill.nut
+++ b/scripts/skills/actives/legend_rust_skill.nut
@@ -8,7 +8,7 @@ this.legend_rust_skill <- this.inherit("scripts/skills/legend_magic_skill", {
 		this.m.DamageInitiativeMax = 45;
 		this.m.ID = "actives.legend_rust";
 		this.m.Name = "Rust";
-		this.m.Description = "Tarnish leather and metal with rapid age, thereby undermining the solidity of the armor worn by your target. Damaged done is based off current initiative.\n Hitchcance is determined by Ranged Skill.";
+		this.m.Description = "Tarnish leather and metal with rapid age, thereby undermining the solidity of the armor worn by your target. Damaged done is based off current initiative.\nHitchcance is determined by Ranged Skill.";
 		this.m.Icon = "skills/rust56.png";
 		this.m.IconDisabled = "skills/rust56_bw.png";
 		this.m.Overlay = "rust56";

--- a/scripts/skills/actives/legend_safeguard_skill.nut
+++ b/scripts/skills/actives/legend_safeguard_skill.nut
@@ -5,7 +5,7 @@ this.legend_safeguard_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_safeguard";
 		this.m.Name = "Safeguard";
-		this.m.Description = "Use your shield to protect an ally, leaving yourself exposed";
+		this.m.Description = "Use your shield to protect an ally, leaving yourself exposed.";
 		this.m.Icon = "skills/fortify_square.png";
 		this.m.IconDisabled = "skills/fortify_square_bw.png";
 		this.m.Overlay = "active_32";

--- a/scripts/skills/actives/legend_shoot_dart_skill.nut
+++ b/scripts/skills/actives/legend_shoot_dart_skill.nut
@@ -7,7 +7,7 @@ this.legend_shoot_dart_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_shoot_dart";
 		this.m.Name = "Shoot Dart";
-		this.m.Description = "A quick puff of air to propel a dart. A hit to the head will put the target to sleep, a hit to the body has a 50% chance to daze the target";
+		this.m.Description = "A quick puff of air to propel a dart. A hit to the head will put the target to sleep, a hit to the body has a 50% chance to daze the target.";
 		this.m.KilledString = "Darted";
 		this.m.Icon = "skills/blowgun_square.png";
 		this.m.IconDisabled = "skills/blowgun_square_sw.png";

--- a/scripts/skills/actives/legend_siphon_skill.nut
+++ b/scripts/skills/actives/legend_siphon_skill.nut
@@ -4,7 +4,7 @@ this.legend_siphon_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_siphon";
 		this.m.Name = "Life Siphon";
-		this.m.Description = "Siphon the life force from your foe to yourself - replinishing your health and diminishing theirs.\n\nIt will never kill your victim and you can\'t draw more health than you are missing. Damage drops off over distance and uses Melee Skill to hit.";
+		this.m.Description = "Siphon the life force from your foe to yourself - replenishing your health and diminishing theirs.\n\nIt will never kill your victim and you can\'t draw more health than you are missing. Damage drops off over distance and uses Melee Skill to hit.";
 		this.m.KilledString = "Frightened to death";
 		this.m.Icon = "skills/siphon_square.png";
 		this.m.IconDisabled = "skills/siphon_square_bw.png";

--- a/scripts/skills/actives/legend_skin_ghoul_claws.nut
+++ b/scripts/skills/actives/legend_skin_ghoul_claws.nut
@@ -15,7 +15,7 @@ this.legend_skin_ghoul_claws <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_skin_ghoul_claws";
 		this.m.Name = "Skin Ghoul Claws";
-		this.m.Description = "Very long and sharp claws that can tear flesh across multiple opponents and leave them bleeding";
+		this.m.Description = "Tear into flesh across multiple opponents and leave them bleading with very long, sharp claws.";
 		this.m.KilledString = "Ripped to shreds";
 		this.m.Icon = "skills/active_21.png";
 		this.m.IconDisabled = "skills/active_21_sw.png";

--- a/scripts/skills/actives/legend_slingstaff_bash_skill.nut
+++ b/scripts/skills/actives/legend_slingstaff_bash_skill.nut
@@ -4,7 +4,7 @@ this.legend_slingstaff_bash_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_slingstaff_bash";
 		this.m.Name = "Slingstaff Bash";
-		this.m.Description = "A brute force attack with the end of your slingstaff";
+		this.m.Description = "A brute force attack with the end of your slingstaff.";
 		this.m.KilledString = "Clubbed to death";
 		this.m.Icon = "skills/staff_bash.png";
 		this.m.IconDisabled = "skills/staff_bash_bw.png";

--- a/scripts/skills/actives/legend_sprint_skill.nut
+++ b/scripts/skills/actives/legend_sprint_skill.nut
@@ -4,7 +4,7 @@ this.legend_sprint_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_sprint";
 		this.m.Name = "Sprint";
-		this.m.Description = "For the remainder of this turn, the Action Point cost for movement is reduced by 1 for each tile, but the Fatigue cost is doubled";
+		this.m.Description = "For the remainder of this turn, the Action Point cost for movement is reduced by 1 for each tile, but the Fatigue cost is doubled.";
 		this.m.Icon = "ui/perks/perk_sprint.png";
 		this.m.IconDisabled = "ui/perks/perk_sprint_sw.png";
 		this.m.Overlay = "perk_37_active";

--- a/scripts/skills/actives/legend_stealth_skill.nut
+++ b/scripts/skills/actives/legend_stealth_skill.nut
@@ -6,7 +6,7 @@ this.legend_stealth_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_stealth";
 		this.m.Name = "Stealth";
-		this.m.Description = "Fade into the environment";
+		this.m.Description = "Fade into the environment.";
 		this.m.Icon = "skills/stealth_square.png";
 		this.m.IconDisabled = "skills/stealth_square_bw.png";
 		this.m.Overlay = "active_15";

--- a/scripts/skills/actives/legend_summon_storm_skill.nut
+++ b/scripts/skills/actives/legend_summon_storm_skill.nut
@@ -14,7 +14,7 @@ this.legend_summon_storm_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_summon_storm";
 		this.m.Name = "Summon Storm";
-		this.m.Description = "Summons rain to the battlefield, anyone caught in the rain will have their vision reduced by 1 and their ranged skill and ranged defense reduces by 10%. If cast when you are already wet, it will be like drinking a lionheart potion.";
+		this.m.Description = "Summons rain to the battlefield. Anyone caught in the rain will have their vision reduced by 1 and their ranged skill and ranged defense reduces by 10%. If cast when you are already wet, it will be like drinking a lionheart potion.";
 		this.m.Icon = "skills/rain_square.png";
 		this.m.IconDisabled = "skills/rain_square_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_tackle_skill.nut
+++ b/scripts/skills/actives/legend_tackle_skill.nut
@@ -4,7 +4,7 @@ this.legend_tackle_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_tackle";
 		this.m.Name = "Tackle";
-		this.m.Description = "Tackle an enemy to the ground. On a hit, decrease their melee defence by 50%, their initiative by 70%, and increases the damage they take by 25%. The success of a tackle is increased based on how fatigued your target is.";
+		this.m.Description = "Tackle an enemy to the ground. On a hit, decrease their melee defence by 50%, their initiative by 70%, and increases the damage they take by 25%. The more fatigued your target, the more likely the tackle is to succeed.";
 		this.m.Icon = "skills/tackle_square.png";
 		this.m.IconDisabled = "skills/tackle_square_bw.png";
 		this.m.Overlay = "active_32";

--- a/scripts/skills/actives/legend_transform_into_bear_skill.nut
+++ b/scripts/skills/actives/legend_transform_into_bear_skill.nut
@@ -6,7 +6,7 @@ this.legend_transform_into_bear_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_transform_into_bear";
 		this.m.Name = "Transform into Bear";
-		this.m.Description = "Enables the character to turn into a bear, requires free hands";
+		this.m.Description = "Enables the character to turn into a bear. Requires free hands.";
 		this.m.Icon = "skills/bear2_square.png";
 		this.m.IconDisabled = "skills/bear2_square_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_transform_into_boar_skill.nut
+++ b/scripts/skills/actives/legend_transform_into_boar_skill.nut
@@ -6,7 +6,7 @@ this.legend_transform_into_boar_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_transform_into_boar";
 		this.m.Name = "Transform into Boar";
-		this.m.Description = "Enables the character to turn into a boar, requires free hands. Temporary Icon sorry";
+		this.m.Description = "Enables the character to turn into a boar. Requires free hands. (Icon is temporary)";
 		this.m.Icon = "skills/blooddrop_square.png";
 		this.m.IconDisabled = "skills/blooddrop_square_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_transform_into_rat_skill.nut
+++ b/scripts/skills/actives/legend_transform_into_rat_skill.nut
@@ -6,7 +6,7 @@ this.legend_transform_into_rat_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_transform_into_rat";
 		this.m.Name = "Transform into Rat";
-		this.m.Description = "Enables the character to turn into a rat, requires free hands";
+		this.m.Description = "Enables the character to turn into a rat. Requires free hands.";
 		this.m.Icon = "skills/rat_transform.png";
 		this.m.IconDisabled = "skills/rat_transform_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_transform_into_tree_skill.nut
+++ b/scripts/skills/actives/legend_transform_into_tree_skill.nut
@@ -6,7 +6,7 @@ this.legend_transform_into_tree_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_transform_into_tree";
 		this.m.Name = "Transform into Schrat";
-		this.m.Description = "Enables the character to turn into a schrat, requires free hands";
+		this.m.Description = "Enables the character to turn into a schrat. Requires free hands.";
 		this.m.Icon = "skills/tree_square.png";
 		this.m.IconDisabled = "skills/tree_square_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_transform_into_wolf_skill.nut
+++ b/scripts/skills/actives/legend_transform_into_wolf_skill.nut
@@ -6,7 +6,7 @@ this.legend_transform_into_wolf_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_transform_into_wolf";
 		this.m.Name = "Transform into Wolf";
-		this.m.Description = "Enables the character to turn into a wolf, requires free hands";
+		this.m.Description = "Enables the character to turn into a wolf. Requires free hands.";
 		this.m.Icon = "skills/wolf2_square.png";
 		this.m.IconDisabled = "skills/wolf2_square_bw.png";
 		this.m.Overlay = "active_12";

--- a/scripts/skills/actives/legend_unarmed_lunge_skill.nut
+++ b/scripts/skills/actives/legend_unarmed_lunge_skill.nut
@@ -12,7 +12,7 @@ this.legend_unarmed_lunge_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_unarmed_lunge";
 		this.m.Name = "Jump Attack";
-		this.m.Description = "A jump forward and attack combined into a single move";
+		this.m.Description = "A jump forward and attack combined into a single move.";
 		this.m.KilledString = "Hit";
 		this.m.Icon = "skills/unarmed_lunge_square.png";
 		this.m.IconDisabled = "skills/unarmed_lunge_square_bw.png";

--- a/scripts/skills/actives/legend_unleash_bear_skill.nut
+++ b/scripts/skills/actives/legend_unleash_bear_skill.nut
@@ -38,7 +38,7 @@ this.legend_unleash_bear_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_unleash_bear";
 		this.m.Name = "Summon Bear";
-		this.m.Description = "Summon a faithful bear. Needs a free tile adjacent. Only one per battle";
+		this.m.Description = "Summon a faithful bear. Needs a free tile adjacent. Only one per battle.";
 		this.m.Icon = "skills/bear_square.png";
 		this.m.IconDisabled = "skills/bear_square_bw.png";
 		this.m.Overlay = "active_165";

--- a/scripts/skills/actives/legend_unleash_cat_skill.nut
+++ b/scripts/skills/actives/legend_unleash_cat_skill.nut
@@ -52,7 +52,7 @@ this.legend_unleash_cat_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_unleash_cat";
 		this.m.Name = "Summon Cat";
-		this.m.Description = "Summon your cat, hopefully it wont just run away. Needs a free tile adjacent.";
+		this.m.Description = "Summon your cat. Hopefully it won\'t just run away. Needs a free tile adjacent.";
 		this.m.Icon = "skills/cat_square.png";
 		this.m.IconDisabled = "skills/cat_square_bw.png";
 		this.m.Overlay = "cat_square";

--- a/scripts/skills/actives/legend_unleash_hound_skill.nut
+++ b/scripts/skills/actives/legend_unleash_hound_skill.nut
@@ -51,7 +51,7 @@ this.legend_unleash_hound_skill <- this.inherit("scripts/skills/actives/legend_u
 	{
 		this.m.ID = "actives.legend_unleash_hound";
 		this.m.Name = "Summon Hound";
-		this.m.Description = "Summon a faithful hound. Needs a free tile adjacent. Can only summon one per combat";
+		this.m.Description = "Summon a faithful hound. Needs a free tile adjacent. Can only summon one per combat.";
 		this.m.Icon = "skills/active_165.png";
 		this.m.IconDisabled = "skills/active_165_sw.png";
 		this.m.Overlay = "active_165";

--- a/scripts/skills/actives/legend_unleash_wolf_skill.nut
+++ b/scripts/skills/actives/legend_unleash_wolf_skill.nut
@@ -53,7 +53,7 @@ this.legend_unleash_wolf_skill <- this.inherit("scripts/skills/actives/legend_un
 	{
 		this.m.ID = "actives.legend_unleash_wolf";
 		this.m.Name = "Summon Wolf";
-		this.m.Description = "Summon a faithful wolf. Needs a free tile adjacent. Only one per battle";
+		this.m.Description = "Summon a faithful wolf. Needs a free tile adjacent. Only one per battle.";
 		this.m.Icon = "skills/wolf2_square.png";
 		this.m.IconDisabled = "skills/wolf2_square_bw.png";
 		this.m.Overlay = "active_165";

--- a/scripts/skills/actives/legend_werewolf_claws_skill.nut
+++ b/scripts/skills/actives/legend_werewolf_claws_skill.nut
@@ -4,7 +4,7 @@ this.legend_werewolf_claws_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_werewolf_claws";
 		this.m.Name = "Direwolf Claws";
-		this.m.Description = "Long and sharp claws that can tear flesh with ease.";
+		this.m.Description = "Tear into flesh with long, sharp claws.";
 		this.m.Icon = "skills/active_21.png";
 		this.m.IconDisabled = "skills/active_21_bw.png";
 		this.m.Overlay = "active_21";

--- a/scripts/skills/actives/legend_wither_skill.nut
+++ b/scripts/skills/actives/legend_wither_skill.nut
@@ -4,7 +4,7 @@ this.legend_wither_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_wither";
 		this.m.Name = "Wither";
-		this.m.Description = "Wither a target for three turns, reducing their damage, fatigue and initiative by [color=" + this.Const.UI.Color.NegativeValue + "]-30%[/color]. The effect reduces by 10% each turn";
+		this.m.Description = "Wither a target for three turns, reducing their damage, fatigue and initiative by [color=" + this.Const.UI.Color.NegativeValue + "]-30%[/color]. The effect reduces by 10% each turn.";
 		this.m.Icon = "skills/wither56_skill.png";
 		this.m.IconDisabled = "skills/wither56_skill_bw.png";
 		this.m.Overlay = "wither";

--- a/scripts/skills/actives/legend_wooden_stake_stab_skill.nut
+++ b/scripts/skills/actives/legend_wooden_stake_stab_skill.nut
@@ -4,7 +4,7 @@ this.legend_wooden_stake_stab_skill <- this.inherit("scripts/skills/skill", {
 	{
 		this.m.ID = "actives.legend_wooden_stake_stab";
 		this.m.Name = "Stab with Wooden Stake";
-		this.m.Description = "A quick and fast stab with the wooden shaft. Deals +100 damage to vampires";
+		this.m.Description = "A quick and fast stab with the wooden shaft. Deals +100 damage to vampires.";
 		this.m.KilledString = "Staked";
 		this.m.Icon = "skills/wooden_stake_square.png";
 		this.m.IconDisabled = "skills/wooden_stake_square_bw.png";


### PR DESCRIPTION
## What?

Fixes various typos - mostly missing `.`s at the end of sentences - in active skill descriptions. Also tackles a few misplaced tenses, misspellings, and comma splices, alongside some outright rephrasing.

## Why?

Most of the issues addressed are incorrect or inconsistent either with the rest of Legends or with the base game.

## Other notes

Perhaps best reviewed commit-by-commit. I did try to group things logically, even if there's not a super natural flow to the work itself.