### PR TITLE
Luft/lone wolf recruitment rework

### DIFF
--- a/mod_legends/hooks/scenarios/world/lone_wolf_scenario.nut
+++ b/mod_legends/hooks/scenarios/world/lone_wolf_scenario.nut
@@ -3,7 +3,7 @@
 	{
 		this.m.ID = "scenario.lone_wolf";
 		this.m.Name = "Lone Wolf";
-		this.m.Description = "[p=c][img]gfx/ui/events/event_35.png[/img][/p][p]You have been traveling for a long time, taking part in tourneys and sparring with young nobles. A hedge knight as tall as a tree, you never needed anybody for long. Is it true still?\n\n[color=#bcad8c]Lone Wolf:[/color] Start with a single experienced hedge knight and great equipment but low funds. All encounters are two-thirds harder than normal.\n[color=#bcad8c]Elite Few:[/color] Can never have more than 12 fighters in your roster.\n[color=#bcad8c]Avatar:[/color] If your lone wolf dies, the campaign ends.\n[color=#c90000]Not a sellsword:[/color] Cannot recruit. Must instead encounter other champions and allies through events to join your cause.[/p]";
+		this.m.Description = "[p=c][img]gfx/ui/events/event_35.png[/img][/p][p]You have been traveling for a long time, taking part in tourneys and sparring with young nobles. A hedge knight as tall as a tree, you never needed anybody for long. Is it true still?\n\n[color=#bcad8c]Lone Wolf:[/color] Start with a single experienced hedge knight with great equipment but low funds. All encounters are two-thirds harder than normal.\n[color=#bcad8c]Elite Few:[/color] Can never have more than 12 fighters in your roster. You may encounter other champions and special allies through events to join your cause.\n[color=#bcad8c]Avatar:[/color] If your lone wolf dies, the campaign ends.\n[color=#c90000]Living Legend:[/color] As your renown grows, the more recruits will be present in towns. Higher renown increases quality of hires, but you will start with being unable to hire anyone.[/p]";
 		this.m.Difficulty = 4;
 		this.m.Order = 150;
 		this.m.IsFixedLook = true;
@@ -137,14 +137,14 @@
 		return false;
 	}
 
-	o.onUpdateHiringRoster <- function ( _roster )
+	o.onUpdateHiringRoster <- function ( _roster ) //dump all hires to start, except donkey
 	{
 		local garbage = [];
 		local bros = _roster.getAll();
 
 		foreach( i, bro in bros )
 		{
-			if (bro.getBackground().getID() != "background.legend_donkey") //this.Const.BackgroundType.Stabled
+			if (bro.getBackground().getID() != "background.legend_donkey")
 			{
 				garbage.push(bro);
 			}
@@ -163,6 +163,98 @@
 		foreach( g in garbage )
 		{
 			_roster.remove(g);
+		}
+	}
+
+	o.onUpdateDraftList( _draftList ) //insert specfic backgrounds at x renown level(s). *most* crafting/support backgrounds ahve been removed from this master list - companions from events cover any gaps re: retinue/camp tasks.
+	{
+		if (this.World.Assets.getBusinessReputation() < 750) { //peasant/lowborn + Squires
+			_draftList.push("brawler_background");
+			_draftList.push("squire_background");
+			_draftList.push("butcher_background");
+			// _draftList.push("caravan_hand_background");
+			_draftList.push("cripple_background");
+			_draftList.push("daytaler_background");
+			// _draftList.push("miller_background");
+			_draftList.push("miner_background");
+			_draftList.push("minstrel_background");
+			// _draftList.push("monk_background");
+			// _draftList.push("peddler_background");
+			_draftList.push("poacher_background");
+			_draftList.push("legend_ironmonger_background");
+			_draftList.push("wildman_background");
+			_draftList.push("lumberjack_background");
+			// _draftList.push("mason_background");
+			_draftList.push("apprentice_background");
+			// _draftList.push("messenger_background");
+			// _draftList.push("eunuch_background");
+			_draftList.push("farmhand_background");
+			_draftList.push("thief_background");
+			_draftList.push("fisherman_background");
+			_draftList.push("flagellant_background");
+			_draftList.push("gambler_background");
+			_draftList.push("gravedigger_background");
+			_draftList.push("graverobber_background");
+			_draftList.push("beggar_background");
+			// _draftList.push("historian_background");
+			_draftList.push("ratcatcher_background");
+			_draftList.push("refugee_background");
+			// _draftList.push("servant_background");
+			_draftList.push("shepard_background");
+			_draftList.push("bowyer_background");
+			// _draftList.push("tailor_background");
+			_draftList.push("vagabond_background");
+			// _draftList.push("legend_herbalist_background");
+		}
+
+		else if (this.World.Assets.getBusinessReputation() < 1500) { //basic fighters
+			_draftList.push("militia_background");
+			_draftList.push("deserter_background");
+			_draftList.push("retired_soldier_background");
+			_draftList.push("cultist_background");
+			_draftList.push("houndmaster_background");
+			_draftList.push("hunter_background");
+			_draftList.push("juggler_background");
+			_draftList.push("killer_on_the_run_background");
+			// _draftList.push("taxidermist_background");
+			_draftList.push("juggler_background");
+			_draftList.push("barbarian_background");
+			_draftList.push("bastard_background");
+			_draftList.push("blacksmith_background");	
+		}
+
+		else if (this.World.Assets.getBusinessReputation() < 2500) { //high tier
+			_draftList.push("adventurous_noble_background");
+			_draftList.push("disowned_noble_background");
+			_draftList.push("beast_hunter_background");	
+			_draftList.push("witchhunter_background");
+			_draftList.push("legend_shieldmaiden_background");	
+			_draftList.push("raider_background");
+		}
+
+		else if (this.World.Assets.getBusinessReputation() < 3500) { //elite
+			_draftList.push("hedge_knight_background");
+			_draftList.push("sellsword_background");
+			_draftList.push("swordmaster_background");
+			_draftList.push("legend_bladedancer_background");
+			_draftList.push("legend_master_archer_background");
+			_draftList.push("assassin_southern_background");
+			_draftList.push("gladiator_background");
+		}
+
+		else if (this.World.Assets.getBusinessReputation() < 4500) { //special
+			_draftList.push("legend_noble_2h");
+			_draftList.push("legend_noble_shield");
+			_draftList.push("legend_noble_ranged");
+			_draftList.push("assassin_background");
+			_draftList.push("legend_man_at_arms_background");
+			_draftList.push("legend_conscript_background");
+			_draftList.push("paladin_background");
+			_draftList.push("legend_inventor_background");
+			_draftList.push("legend_crusader_background");
+			_draftList.push("legend_berserker_background");	
+			_draftList.push("legend_vala_background"); //balance-wise, I think this is fine, 12 bro slots means this won't get out of control and having 1-3 valas could be a fun gameplay loop. Women are scary.
+			_draftList.push("legend_ranger_background");
 		}
 	}
 

--- a/mod_legends/hooks/scenarios/world/lone_wolf_scenario.nut
+++ b/mod_legends/hooks/scenarios/world/lone_wolf_scenario.nut
@@ -168,7 +168,7 @@
 
 	o.onUpdateDraftList( _draftList ) //insert specfic backgrounds at x renown level(s). *most* crafting/support backgrounds ahve been removed from this master list - companions from events cover any gaps re: retinue/camp tasks.
 	{
-		if (this.World.Assets.getBusinessReputation() < 750) { //peasant/lowborn + Squires
+		if (this.World.Assets.getBusinessReputation() > 750) { //peasant/lowborn + Squires
 			_draftList.push("brawler_background");
 			_draftList.push("squire_background");
 			_draftList.push("butcher_background");
@@ -207,7 +207,7 @@
 			// _draftList.push("legend_herbalist_background");
 		}
 
-		else if (this.World.Assets.getBusinessReputation() < 1500) { //basic fighters
+		if (this.World.Assets.getBusinessReputation() > 1500) { //basic fighters
 			_draftList.push("militia_background");
 			_draftList.push("deserter_background");
 			_draftList.push("retired_soldier_background");
@@ -223,7 +223,7 @@
 			_draftList.push("blacksmith_background");	
 		}
 
-		else if (this.World.Assets.getBusinessReputation() < 2500) { //high tier
+		if (this.World.Assets.getBusinessReputation() > 2500) { //high tier
 			_draftList.push("adventurous_noble_background");
 			_draftList.push("disowned_noble_background");
 			_draftList.push("beast_hunter_background");	
@@ -232,7 +232,7 @@
 			_draftList.push("raider_background");
 		}
 
-		else if (this.World.Assets.getBusinessReputation() < 3500) { //elite
+		if (this.World.Assets.getBusinessReputation() > 3500) { //elite
 			_draftList.push("hedge_knight_background");
 			_draftList.push("sellsword_background");
 			_draftList.push("swordmaster_background");
@@ -242,7 +242,7 @@
 			_draftList.push("gladiator_background");
 		}
 
-		else if (this.World.Assets.getBusinessReputation() < 4500) { //special
+		if (this.World.Assets.getBusinessReputation() > 4500) { //special
 			_draftList.push("legend_noble_2h");
 			_draftList.push("legend_noble_shield");
 			_draftList.push("legend_noble_ranged");
@@ -251,10 +251,7 @@
 			_draftList.push("legend_conscript_background");
 			_draftList.push("paladin_background");
 			_draftList.push("legend_inventor_background");
-			_draftList.push("legend_crusader_background");
 			_draftList.push("legend_berserker_background");	
-			_draftList.push("legend_vala_background"); //balance-wise, I think this is fine, 12 bro slots means this won't get out of control and having 1-3 valas could be a fun gameplay loop. Women are scary.
-			_draftList.push("legend_ranger_background");
 		}
 	}
 


### PR DESCRIPTION
…recruitment of specific backgrounds in towns based on company renown, in divisions. As your renown grows, the more recruits will be present in towns. Higher renown increases quality of hires, but you will start with being unable to hire anyone.

==============
Hello Chop my beloved, I think this is all correct but if you don't mind, please have a look at the recruitment draftlist code just in case I've mentally slipped on something. Thanks babe. Love you. x