### PR TITLE
Backgrounds new OverrideVeteranPerks to use for specific backgrounds (Draft)

### DIFF
--- a/mod_legends/hooks/entity/tactical/player.nut
+++ b/mod_legends/hooks/entity/tactical/player.nut
@@ -1292,6 +1292,11 @@
 			this.fillTalentValues(3);
 			this.fillAttributeLevelUpValues(this.Const.XP.MaxLevelWithPerkpoints - 1);
 		}
+
+		if(!::MSU.isNull(background.m.OverrideVeteranPerks))
+		{
+			this.setVeteranPerks(background.m.OverrideVeteranPerks);
+		}
 	}
 
 	o.getAlignment <- function()

--- a/mod_legends/hooks/skills/backgrounds/belly_dancer_background.nut
+++ b/mod_legends/hooks/skills/backgrounds/belly_dancer_background.nut
@@ -37,6 +37,7 @@
 		this.m.HairColors = this.Const.HairColors.SouthernYoung;
 		this.m.BeardChance = 1;
 		this.m.Ethnicity = 1;
+		this.m.OverrideVeteranPerks = 2;
 		this.m.BackgroundType = this.Const.BackgroundType.Female | this.Const.BackgroundType.Performing;
 		this.m.Modifiers.Barter = this.Const.LegendMod.ResourceModifiers.Barter[1];
 		this.m.PerkTreeDynamic = {

--- a/mod_legends/hooks/skills/backgrounds/character_background.nut
+++ b/mod_legends/hooks/skills/backgrounds/character_background.nut
@@ -102,6 +102,7 @@
 	o.m.PerkTreeMap <- null;
 	o.m.PerkTree <- null;
 	o.m.IsGuaranteed <- [];
+	o.m.OverrideVeteranPerks <- null;
 
 	local create = o.create;
 	o.create = function()

--- a/mod_legends/hooks/skills/backgrounds/lindwurm_slayer_background.nut
+++ b/mod_legends/hooks/skills/backgrounds/lindwurm_slayer_background.nut
@@ -45,6 +45,7 @@
 		this.m.Beards = this.Const.Beards.Untidy;
 		this.m.Bodies = this.Const.Bodies.Muscular;
 		this.m.Level = this.Math.rand(2, 4);
+		this.m.OverrideVeteranPerks = 2;
 		this.m.AlignmentMin = this.Const.LegendMod.Alignment.Cruel;
 		this.m.AlignmentMax = this.Const.LegendMod.Alignment.Chivalrous;
 		this.m.BackgroundType = this.Const.BackgroundType.Combat | this.Const.BackgroundType.Ranger | this.Const.BackgroundType.ExpertHunter;

--- a/scripts/skills/backgrounds/legend_crusader_background.nut
+++ b/scripts/skills/backgrounds/legend_crusader_background.nut
@@ -54,6 +54,7 @@ this.legend_crusader_background <- this.inherit("scripts/skills/backgrounds/char
 		this.m.AlignmentMin = this.Const.LegendMod.Alignment.Good;
 		this.m.AlignmentMax = this.Const.LegendMod.Alignment.Saintly;
 		this.m.Level = 3;
+		this.m.OverrideVeteranPerks = 2; 
 		this.m.BackgroundType = this.Const.BackgroundType.Crusader | this.Const.BackgroundType.Combat | this.Const.BackgroundType.OffendedByViolence | this.Const.BackgroundType.Untalented;
 		this.m.Modifiers.Healing = this.Const.LegendMod.ResourceModifiers.Healing[1];
 		this.m.Modifiers.Salvage = this.Const.LegendMod.ResourceModifiers.Salvage[1];

--- a/scripts/skills/backgrounds/legend_druid_background.nut
+++ b/scripts/skills/backgrounds/legend_druid_background.nut
@@ -56,6 +56,7 @@ this.legend_druid_background <- this.inherit("scripts/skills/backgrounds/charact
 		this.m.BeardChance = 100;
 		this.m.Bodies = this.Const.Bodies.Muscular;
 		this.m.Level = 3;
+		this.m.OverrideVeteranPerks = 2;
 		this.m.BackgroundType = this.Const.BackgroundType.Combat | this.Const.BackgroundType.Lowborn | this.Const.BackgroundType.Untalented | this.Const.BackgroundType.Druid | this.Const.BackgroundType.Ranger;
 		// this.m.AlignmentMin = this.Const.LegendMod.Alignment.Merciless;
 		// this.m.AlignmentMax = this.Const.LegendMod.Alignment.Good;

--- a/scripts/skills/backgrounds/legend_vala_background.nut
+++ b/scripts/skills/backgrounds/legend_vala_background.nut
@@ -42,6 +42,7 @@ this.legend_vala_background <- this.inherit("scripts/skills/backgrounds/characte
 		this.m.Modifiers.Injury = this.Const.LegendMod.ResourceModifiers.Injury[3];
 		this.m.Modifiers.Enchanting = 1.0;
 		this.m.Level = 2;
+		this.m.OverrideVeteranPerks = 2;
 		this.m.PerkTreeDynamic = {
 			Weapon = [
 				this.Const.Perks.StaffTree


### PR DESCRIPTION
character_background.nut now has a new OverrideVeteranPerks default null member that can be defined in specific backgrounds.
This member will be checked in setStartValuesEx function in Player.nut to set the correct VeteranPerks property for that unique actor. To first view setStartValuesEx is called only when recruiting so this doesn't seem to work for already recruited bros.

currently updated specific backgrounds:
- belly dancer
- lindwurm slayer
- crusader
- druid
- vala