### PR TITLE
Fix `attackEntity` not taking into account `IsShieldRelevant`

### DIFF
--- a/mod_legends/hooks/skills/skill.nut
+++ b/mod_legends/hooks/skills/skill.nut
@@ -1225,6 +1225,14 @@
 			toHit = toHit + this.Const.Combat.LevelDifferenceToHitMalus * levelDifference;
 		}
 
+		if (!this.m.IsShieldRelevant) {
+			local shield = _targetEntity.getItems().getItemAtSlot(this.Const.ItemSlot.Offhand);
+			if (shield != null && shield.isItemType(this.Const.Items.ItemType.Shield)) {
+				local shieldBonus = (this.m.IsRanged ? shield.getRangedDefense() : shield.getMeleeDefense()) * (_targetEntity.getCurrentProperties().IsSpecializedInShields ? 1.25 : 1.0);
+				toHit = toHit + shieldBonus;
+			}
+		}
+
 		local shieldBonus = 0;
 		local shield = _targetEntity.getItems().getItemAtSlot(this.Const.ItemSlot.Offhand);
 		if (shield != null && !shield.isItemType(this.Const.Items.ItemType.Shield))


### PR DESCRIPTION
`getHitchance` takes `IsShieldRelevant` into account, but `attackEntity` doesn´t.

This made flails unintentionally loose their main bonus.

Should also fix slinger spins.