### PR TITLE
Add text for event Husk vs Witch

### DIFF
--- a/scripts/events/events/legends/legends_husk_vs_witch.nut
+++ b/scripts/events/events/legends/legends_husk_vs_witch.nut
@@ -1,0 +1,41 @@
+// --- Husk vs Witch --- //
+//  Event for Husk background for the Cultist origin.
+//  Happens during witch contract instead of combat with Witch.
+
+//Requirements:
+//  Witch Contract Active
+//  Contract’s Witch Attacks the Party
+//  Husk bro in party: (lvl10+) + (Davkul Candles: 4+)
+//  Husk bro has 60%+ hp
+
+//Event Characters:
+//  %EldersSon% - Character from contract
+//  %ElderName% - Character from contract
+//  %ChosenHusk% - Party Member
+
+//Results:
+//  Contract completed.
+//  Reward: Witch battle loot
+//  %ChosenHusk% effects
+//  Takes damage: 10%-59%
+//  If not having Resilient perk: random light wound
+//  Gains +3-5 Resolve permanently
+
+//Buttons:
+//  [Davkul awaits us all.] - Event exit button
+
+//Word Count: 265
+
+// --- Event Text --- //
+// Empty gazes stare deep into the unnatural fog, thick with a malevolent green tone, concealing everything within. When the mysterious mist began to appear, %CompanyName% remained in deathly silence, except for the whimpering of %EldersSon%. It was not the bravest hour for %ElderName%’s son, who deeply regretted asking %ChosenHusk% any questions about the upcoming battle.
+//
+// When the soft tapping of a walking cane from within the thick fog finally reached his ears, the elder son's whimpering turned into cries for help. The ugly old witch was closer than expected. She stood just in front of %ChosenHusk%, whispering her magical lies…
+//
+// It was a grave mistake as a deep look into %ChosenHusk%‘s eyes froze her into her place. She could see shattered pieces of mind drowning in the void, small islands of sanity floating in the endless ocean of emptiness. But in all that nothingness, something was hidden, and it had been staring at her the entire time. It was primordial all consuming darkness, which awaits us all. There was no one to charm, merely hollow flesh to which pain and misery simply brings the blessing of feeling alive.
+//
+// The old crone managed to utter an ancient curse just as %ChosenHusk%, charging forward, slammed them both to the ground. Powerful punches brutally deformed the repulsive woman’s face even further. Hot blood poured onto her in waterfalls as the ruinous curse consumed and broke %ChosenHusk%’s body as well. Nevertheless, the blows continued to fall.
+//
+// And suddenly, the end came.
+// %ChosenHusk% rises, bleeding from every visible orifice, and utters: “The witch is with Davkul now.”
+
+// [Davkul awaits us all.]


### PR DESCRIPTION
## Husk vs Witch

Event for Husk background for the Cultist origin.  
Happens during witch contract instead of combat with Witch.

---

### Requirements
- Witch Contract Active  
- Contract’s Witch Attacks the Party  
- Husk bro in party: (lvl10+) + (Davkul Candles: 4+)  
- Husk bro has 60%+ hp

---

### Event Characters
- %EldersSon% - Character from contract  
- %ElderName% - Character from contract  
- %ChosenHusk% - Party Member

---

### Results
- Contract completed  
- Reward: Witch battle loot  
- %ChosenHusk% effects:  
  - Takes damage: 10%-59%  
  - If not having Resilient perk: random light wound  
  - Gains +3-5 Resolve permanently

---

### Buttons
- [Davkul awaits us all.] - Event exit button

---

### Word Count
- 265