### PR TITLE
Bug fix for armor layer switching when inventory is full

### DIFF
--- a/scripts/items/legend_armor/legend_armor.nut
+++ b/scripts/items/legend_armor/legend_armor.nut
@@ -437,6 +437,7 @@ this.legend_armor <- this.inherit("scripts/items/armor/armor", {
 		if (this.m.Upgrades[_upgrade.getType()] != null)
 		{
 			oldItem = this.removeUpgrade(_upgrade.getType());
+			if(oldItem==null) return false
 		}
 		this.m.Upgrades[_upgrade.getType()] = _upgrade;
 		_upgrade.setArmor(this);
@@ -961,4 +962,5 @@ this.legend_armor <- this.inherit("scripts/items/armor/armor", {
 		}
 	}
 });
+
 

--- a/scripts/items/legend_armor/legend_armor.nut
+++ b/scripts/items/legend_armor/legend_armor.nut
@@ -437,7 +437,7 @@ this.legend_armor <- this.inherit("scripts/items/armor/armor", {
 		if (this.m.Upgrades[_upgrade.getType()] != null)
 		{
 			oldItem = this.removeUpgrade(_upgrade.getType());
-			if(oldItem==null) return false
+			if (oldItem == null) return false;
 		}
 		this.m.Upgrades[_upgrade.getType()] = _upgrade;
 		_upgrade.setArmor(this);
@@ -962,5 +962,6 @@ this.legend_armor <- this.inherit("scripts/items/armor/armor", {
 		}
 	}
 });
+
 
 

--- a/scripts/items/legend_helmets/legend_helmet.nut
+++ b/scripts/items/legend_helmets/legend_helmet.nut
@@ -498,7 +498,7 @@ this.legend_helmet <- this.inherit("scripts/items/helmets/helmet", {
 		if (this.m.Upgrades[slot] != null)
 		{
 			oldItem = this.removeUpgrade(slot);
-			if(oldItem==null) return false
+			if (oldItem == null) return false;
 		}
 
 		this.m.Upgrades[slot] = _upgrade;

--- a/scripts/items/legend_helmets/legend_helmet.nut
+++ b/scripts/items/legend_helmets/legend_helmet.nut
@@ -498,6 +498,7 @@ this.legend_helmet <- this.inherit("scripts/items/helmets/helmet", {
 		if (this.m.Upgrades[slot] != null)
 		{
 			oldItem = this.removeUpgrade(slot);
+			if(oldItem==null) return false
 		}
 
 		this.m.Upgrades[slot] = _upgrade;


### PR DESCRIPTION
Bug fix.
Issue: Switching armor layers when your inventory is full will make the old layer on the armor be a duplicate of the new layer, and the new layer stays the same in the inventory. This is kind of a duplication after the save is reloaded.
My fix stops switching process if inventory is full and there is a existing layer. If you can make it possible to switch layers correctly when inventory is full that's better.