### PR TITLE
Stash Fixes

### DIFF
--- a/mod_legends/hooks/entity/world/player_party.nut
+++ b/mod_legends/hooks/entity/world/player_party.nut
@@ -351,23 +351,17 @@
 
 	o.calculateModifiers <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc == 1)	//Leonion's fix
-		{
-			this.calculateBarterMult();
-			this.calculateWageModifier();
-			this.calculateFoodModifier();
-			this.calculateAmmoModifier();
-			this.calculateArmorPartsModifier();
-			this.calculateMedsModifier();
-			this.calculateStashModifier();
-		}
+		this.calculateBarterMult();
+		this.calculateWageModifier();
+		this.calculateFoodModifier();
+		this.calculateAmmoModifier();
+		this.calculateArmorPartsModifier();
+		this.calculateMedsModifier();
+		this.calculateStashModifier();
 	}
 
 	o.calculateFoodModifier <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		foreach( bro in this.World.getPlayerRoster().getAll() )
 		{
 			if (!bro.getSkills().hasPerk(::Legends.Perk.LegendQuartermaster))
@@ -380,9 +374,6 @@
 
 	o.calculateWageModifier <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		foreach( bro in this.World.getPlayerRoster().getAll() )
 		{
 			if (bro.getSkills().hasPerk(::Legends.Perk.LegendPaymaster)) {
@@ -394,9 +385,6 @@
 
 	o.calculateBarterMult <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		local barterMult = 0.0;
 		local greed = 1;
 		foreach (bro in this.World.getPlayerRoster().getAll())
@@ -414,9 +402,6 @@
 
 	o.calculateAmmoModifier <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		local s = 0;
 		foreach( bro in this.World.getPlayerRoster().getAll() )
 		{
@@ -427,9 +412,6 @@
 
 	o.calculateArmorPartsModifier <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		local s = 0;
 		foreach( bro in this.World.getPlayerRoster().getAll() )
 		{
@@ -440,9 +422,6 @@
 
 	o.calculateMedsModifier <- function ()
 	{
-		if (this.World.State.m.AppropriateTimeToRecalc != 1)
-			return;
-
 		local s = 0;
 		foreach( bro in this.World.getPlayerRoster().getAll() )
 		{
@@ -453,27 +432,22 @@
 
 	o.calculateStashModifier <- function (resize = true)
 	{
-		if (::World.State.m.AppropriateTimeToRecalc == 1)	////Leonion's fix
+		local s = ::World.Flags.getAsInt("LegendStartingStash");
+
+		foreach( bro in ::World.getPlayerRoster().getAll())
 		{
-			local s = ::World.Flags.getAsInt("LegendStartingStash");
-
-			foreach( bro in ::World.getPlayerRoster().getAll())
-			{
-				s += bro.getStashModifier();
-			}
-
-			if (this.World.Retinue.hasFollower("follower.quartermaster"))
-			{
-				s += 27;
-			}
-
-			if (resize && s != ::Stash.getCapacity())
-				::Stash.resize(s);
-
-			return s;
+			s += bro.getStashModifier();
 		}
 
-		return ::Stash.getCapacity();
+		if (this.World.Retinue.hasFollower("follower.quartermaster"))
+		{
+			s += 27;
+		}
+
+		if (resize && s != ::Stash.getCapacity())
+			::Stash.resize(s);
+
+		return s;
 	}
 
 	local onInit = o.onInit;

--- a/mod_legends/hooks/retinue/followers/quartermaster_follower.nut
+++ b/mod_legends/hooks/retinue/followers/quartermaster_follower.nut
@@ -27,10 +27,10 @@
 			this.World.Assets.m.MedicineMaxAdditional  = 50;
 		if ("ArmorPartsMaxAdditional" in this.World.Assets.m)
 			this.World.Assets.m.ArmorPartsMaxAdditional = 50;
+		::World.State.getPlayer().calculateStashModifier();
 	}
 
 	o.onEvaluate = function () {
 		this.follower.onEvaluate();
 	}
 });
-

--- a/mod_legends/hooks/retinue/retinue_manager.nut
+++ b/mod_legends/hooks/retinue/retinue_manager.nut
@@ -68,7 +68,9 @@
 		local before = ::World.Assets.getStash().getCapacity();
 		upgradeInventory();
 		local diff = ::World.Assets.getStash().getCapacity() - before;
+		::World.Assets.getStash().resize(before);
 		::World.Flags.increment("LegendStartingStash", diff);
+		::World.State.getPlayer().calculateStashModifier();
 	}
 
 	o.hasFollowersToRemove <- function ()

--- a/mod_legends/hooks/states/world/asset_manager.nut
+++ b/mod_legends/hooks/states/world/asset_manager.nut
@@ -906,7 +906,6 @@
 
 	o.restoreEquipment = function ()
 	{
-		this.World.State.m.AppropriateTimeToRecalc = 0;	//Leonion's fix
 		foreach( s in this.m.RestoreEquipment )
 		{
 			local bro = this.Tactical.getEntityByID(s.ID);
@@ -1021,7 +1020,6 @@
 		}
 
 		this.m.RestoreEquipment = [];
-		this.World.State.m.AppropriateTimeToRecalc = 1;	//Leonion's fix
 		this.World.State.getPlayer().calculateModifiers();	//Leonion's fix
 	}
 
@@ -1225,16 +1223,6 @@
 			this.setFormationName(i, _in.readString())
 		}
 		this.m.LastDayResourcesUpdated = _in.readU16();
-
-		local current = getStash().getCapacity();
-		local s = 0;
-
-		foreach( bro in ::World.getPlayerRoster().getAll())
-		{
-			s += bro.getStashModifier();
-		}
-
-		::World.Flags.set("LegendStartingStash", ::Math.max(0, current - s)); // switch to the new way to calculate stash modifier
 	}
 
 });

--- a/mod_legends/hooks/states/world_state.nut
+++ b/mod_legends/hooks/states/world_state.nut
@@ -6,7 +6,6 @@
 	o.m.Camp <- null;
 	o.m.IDToRef <- array(27, -1);
 	o.m.DistantVisionBonus <- false;
-	o.m.AppropriateTimeToRecalc <- 0; //Leonion's fix
 	o.m.Encounters <- null;
 
 	o.getBrothersInReserves <- function ()
@@ -100,24 +99,21 @@
 		if (::Time.getRealTimeF() - m.CampaignLoadTime < 4.0)
 			return;
 
-		m.AppropriateTimeToRecalc = 0;
 		loadCampaign(_campaignFileName);
 	}
 
 	o.onCalculatePlayerPartyModifiers <- function()
 	{
-		m.AppropriateTimeToRecalc = 1;
-		getPlayer().calculateModifiers(); //Leonion's fix
+		getPlayer().calculateModifiers();
 	}
 
 	local startNewCampaign = o.startNewCampaign;
 	o.startNewCampaign = function()
 	{
-		m.AppropriateTimeToRecalc = 0; // set to 0 as you don't want it to update those modifiers
 		::Legends.IsStartingNewCampaign = true;
 		startNewCampaign();
-		::World.setFogOfWar(!::Legends.Mod.ModSettings.getSetting("DebugMap").getValue()); //
-		::World.Crafting.resetAllBlueprints(); //
+		::World.setFogOfWar(!::Legends.Mod.ModSettings.getSetting("DebugMap").getValue()); 
+		::World.Crafting.resetAllBlueprints();
 		onCalculatePlayerPartyModifiers();
 		::Legends.IsStartingNewCampaign = false;
 	}


### PR DESCRIPTION
Sorry, forgot i had a pr on the previous branch.
Anyway, this fixed some inventory issues, specifically the ordered inventory retinue duplicating upon load save. It should also update capacity on more instances, rather than only upon loading a save.
Im sure I forgot something somewhere, but stash capacity was working as intended during my testing.