### PR TITLE
QoL: Perk groups in recruit's known perks tooltip

### DIFF
--- a/mod_legends/afterHooks/perk_to_perk_groups_mapping.nut
+++ b/mod_legends/afterHooks/perk_to_perk_groups_mapping.nut
@@ -1,0 +1,232 @@
+::Legends.Perks.PerkToPerkGroupMap <- {};
+
+::Legends.Perks.PerkGroupCategoriesOrder <- [
+	"Weapon",
+	"Defense",
+	"Traits",
+	"Enemy",
+	"Class",
+	"Profession",
+	"Magic",
+	"Other"
+]
+
+// Map to get the priority of a perk group category, as ordered in ::Legends.Perks.PerkGroupCategoriesOrder
+// ::Legends.Perks.PerkGroupCategoriesPriority
+// {
+// 	Weapon = 0,
+// 	Defense = 1,
+// 	Traits = 2,
+// 	Enemy = 3,
+// 	Class = 4,
+// 	Profession = 5,
+// 	Magic = 6,
+// 	Other = 7
+// }
+::Legends.Perks.PerkGroupCategoriesPriority <- {};
+foreach(key, value in ::Legends.Perks.PerkGroupCategoriesOrder)
+{
+	::Legends.Perks.PerkGroupCategoriesPriority[value] <- key;
+}
+
+// {
+// 	Weapon = [],
+// 	Defense = [],
+// 	Traits = [],
+// 	Enemy = [],
+// 	Class = [],
+// 	Profession = [],
+// 	Magic = [],
+// 	Other = []
+// }
+::Legends.Perks.buildPerkGroupCategoriesTableOfArrays <- function()
+{
+	local ret = {};
+	foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
+	{
+		ret[category] <- [];
+	};
+	return ret;
+};
+
+// {
+// 	Weapon = {},
+// 	Defense = {},
+// 	Traits = {},
+// 	Enemy = {},
+// 	Class = {},
+// 	Profession = {},
+// 	Magic = {},
+// 	Other = {}
+// }
+::Legends.Perks.buildPerkGroupCategoriesTableOfTables <- function()
+{
+	local ret = {};
+	foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
+	{
+		ret[category] <- {};
+	};
+	return ret;
+};
+
+// Call this when you need an array, where the index corresponds to a perk group category as ordered in ::Legends.Perks.PerkGroupCategoriesOrder
+// [
+// 	null,
+// 	null,
+// 	null,
+// 	null,
+// 	null,
+// 	null,
+// 	null,
+// 	null
+// ]
+::Legends.Perks.buildPerkGroupCategoriesArray <- function()
+{
+	ret = [];
+	foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
+	{
+		ret.push(null);
+	}
+	return ret;
+};
+
+// Call this when you need an array of arrays, where the index corresponds to a perk group category as ordered in ::Legends.Perks.PerkGroupCategoriesOrder
+// [
+// 	[],
+// 	[],
+// 	[],
+// 	[],
+// 	[],
+// 	[],
+// 	[],
+// 	[]
+// ]
+::Legends.Perks.buildPerkGroupCategoriesArrayOfArrays <- function()
+{
+	local ret = [];
+	foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
+	{
+		ret.push([]);
+	}
+	return ret;
+};
+
+// Record the category for each perk group that belongs to a category
+foreach (key, category in ::Const.Perks)
+{
+	if ("GroupsCategory" in category)
+	{
+		// ::MSU.Log.printData("Handling Category: " + key);
+		foreach (group in category.Tree)
+		{
+			group.Category <- category.GroupsCategory;
+		}
+	}
+}
+
+// Populate ::Legends.Perks.PerkToPerkGroupMap
+// key: a number matching the index of the corresponding perk in ::Const.Perks.PerkDefObjects
+// value: a table containing information regarding any and all perk groups that the perk belongs to
+foreach (key, group in ::Const.Perks)
+{
+	// Only handle perk groups
+	if (!("Name" in group))
+		continue;
+
+	// ::MSU.Log.printData("Handling Group: " + key);
+	group.Perks <- []; // single array to store all the perkDefs that the perk group comprises
+	foreach (row in group.Tree) {
+		foreach (perkDef in row) {
+			
+			group.Perks.push(perkDef);
+			
+			if (!(perkDef in ::Legends.Perks.PerkToPerkGroupMap))
+			{
+				::Legends.Perks.PerkToPerkGroupMap[perkDef] <- {
+					Groups = [],
+					Const = ::Const.Perks.PerkDefObjects[perkDef].Const
+				};
+			}
+			local category = "Category" in group ? group.Category : "Other";
+			local entry = {
+				ID = group.ID,
+				Name = group.Name,
+				Category = category
+			};
+			
+			// ::MSU.Log.printData("Perk " + ::Const.Perks.PerkDefObjects[perkDef].Const + " from Group [" + key + "] categorized as [" + entry.Category + "]");
+			::Legends.Perks.PerkToPerkGroupMap[perkDef].Groups.push(entry);
+		}
+	}
+}
+
+// Update all PerkDefObjects to add PerkGroups
+foreach (perk in ::Const.Perks.PerkDefObjects)
+{
+	local key = ::Legends.Perk[perk.Const];
+	
+	// Handle Perks that do not belong to any Perk Group
+	if (!(key in ::Legends.Perks.PerkToPerkGroupMap))
+	{
+		local entry = {
+			ID = "Other",
+			Name = "Other",
+			Category = "Other"
+		};
+
+		perk.PerkGroups <- [];
+		perk.PerkGroups.push(entry);
+
+		continue;
+	}
+
+	// Handle Perks that belong to Perk Groups
+	if ("PerkGroups" in perk)
+	{
+		perk.PerkGroups = ::Legends.Perks.PerkToPerkGroupMap[key].Groups;
+	}
+	else
+	{
+		perk.PerkGroups <- ::Legends.Perks.PerkToPerkGroupMap[key].Groups;
+	}
+}
+
+// Check and resolve any perk group ID mismatches
+foreach (key, value in ::Const.Perks)
+{
+	if ("Name" in value && key != value.ID)
+	{
+		::logWarning("Detected mismatched perk group key and ID: ::Const.Perks." + key + ".ID = " + value.ID);
+		::Const.Perks[key].ID = key;
+		::logWarning("Updated mismatched perk group key and ID: ::Const.Perks." + key + ".ID = " + value.ID);
+	}
+}
+
+/**
+ * 	Check if the Perk Group's perks can all be found in a given table of perkDefs
+ * 
+ *	Will throw error if ::Const.Perks[_id].ID does not match the variable name
+ * 	For example, the following must be true:
+ * 	::Const.Perks.Foo.ID = "Foo"
+ * 
+ * 	@param _id - The ID of a perk group
+ *	@param _perkDefsTable - A table whose keys are perkDefs
+ * 
+ * 	@return a boolean
+ */
+::Legends.Perks.isPerkGroupFullyRepresented <- function (_id, _perkDefsTable)
+{
+	if (_id == "Other")
+	{
+		return false;
+	}
+	
+	foreach (perkDef in ::Const.Perks[_id].Perks)
+	{
+		if (!(perkDef in _perkDefsTable))
+		{
+			return false;
+		}
+	}
+	return true;
+}

--- a/mod_legends/config/z_perks_tree_class.nut
+++ b/mod_legends/config/z_perks_tree_class.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.PoisonClassTree <- {
 	ID = "PoisonClassTree",
 	Name = "Poison",
+	Icon = "ui/perks/mastery_poison.png",
 	Descriptions = [
 		"poisons"
 	],
@@ -23,6 +24,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BeastClassTree <- {
 	ID = "BeastClassTree",
 	Name = "Nets",
+	Icon = "ui/perks/net_perk.png",
 	Descriptions = [
 		"catching beasts"
 	],
@@ -38,8 +40,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.TailorClassTree <- {
-ID = "TailorClassTree",
+	ID = "TailorClassTree",
 	Name = "Trendy",
+	Icon = "ui/perks/fashionable.png",
 	Descriptions = [
 		"tailoring"
 	],
@@ -57,6 +60,7 @@ ID = "TailorClassTree",
 ::Const.Perks.HealerClassTree <- {
 	ID = "HealerClassTree",
 	Name = "Healing",
+	Icon = "ui/perks/bandage_circle.png",
 	Descriptions = [
 		"healing"
 	],
@@ -74,6 +78,7 @@ ID = "TailorClassTree",
 ::Const.Perks.FaithClassTree <- {
 	ID = "FaithClassTree",
 	Name = "Faith",
+	Icon = "ui/perks/prayer_purple.png",
 	Descriptions = [
 		"faith"
 	],
@@ -91,6 +96,7 @@ ID = "TailorClassTree",
 ::Const.Perks.KnifeClassTree <- {
 	ID = "KnifeClassTree",
 	Name = "Knives",
+	Icon = "ui/perks/perk_spec_dagger.png",
 	Descriptions = [
 		"knives"
 	],
@@ -108,6 +114,7 @@ ID = "TailorClassTree",
 ::Const.Perks.ButcherClassTree <- {
 	ID = "ButcherClassTree",
 	Name = "Butcher",
+	Icon = "ui/perks/perk_spec_butcher.png",
 	Descriptions = [
 		"butchery"
 	],
@@ -125,6 +132,7 @@ ID = "TailorClassTree",
 ::Const.Perks.HammerClassTree <- {
 	ID = "HammerClassTree",
 	Name = "Blacksmith",
+	Icon = "ui/perks/perk_spec_smith.png",
 	Descriptions = [
 		"hammers"
 	],
@@ -142,6 +150,7 @@ ID = "TailorClassTree",
 ::Const.Perks.MilitiaClassTree <- {
 	ID = "MilitiaClassTree",
 	Name = "Militia",
+	Icon = "ui/perks/perk_spec_militia.png",
 	Descriptions = [
 		"militia"
 	],
@@ -159,6 +168,7 @@ ID = "TailorClassTree",
 ::Const.Perks.ConArtistTree <- {
 	ID = "ConArtistTree",
 	Name = "Con Artist",
+	Icon = "ui/perks/sleight_of_hand.png",
 	Descriptions = [
 		"sleight of hand"
 	],
@@ -176,6 +186,7 @@ ID = "TailorClassTree",
 ::Const.Perks.PickaxeClassTree <- {
 	ID = "PickaxeClassTree",
 	Name = "Miner",
+	Icon = "ui/perks/perk_spec_pickaxe.png",
 	Descriptions = [
 		"pickaxes"
 	],
@@ -193,6 +204,7 @@ ID = "TailorClassTree",
 ::Const.Perks.PitchforkClassTree <- {
 	ID = "PitchforkClassTree",
 	Name = "Farmer",
+	Icon = "ui/perks/perk_spec_bitchfork.png",
 	Descriptions = [
 		"pitchforks"
 	],
@@ -210,6 +222,7 @@ ID = "TailorClassTree",
 ::Const.Perks.ShortbowClassTree <- {
 	ID = "ShortbowClassTree",
 	Name = "Shortbow",
+	Icon = "ui/perks/perk_spec_shortbow.png",
 	Descriptions = [
 		"shortbows"
 	],
@@ -227,6 +240,7 @@ ID = "TailorClassTree",
 ::Const.Perks.ShovelClassTree <- {
 	ID = "ShovelClassTree",
 	Name = "Gravedigger",
+	Icon = "ui/perks/perk_spec_shovel.png",
 	Descriptions = [
 		"shovels"
 	],
@@ -244,6 +258,7 @@ ID = "TailorClassTree",
 ::Const.Perks.WoodaxeClassTree <- {
 	ID = "WoodaxeClassTree",
 	Name = "Woodsman",
+	Icon = "ui/perks/perk_spec_woodsman.png",
 	Descriptions = [
 		"axes"
 	],
@@ -261,6 +276,7 @@ ID = "TailorClassTree",
 ::Const.Perks.SickleClassTree <- {
 	ID = "SickleClassTree",
 	Name = "Herbalist",
+	Icon = "ui/perks/perk_spec_sickle.png",
 	Descriptions = [
 		"sickles"
 	],
@@ -278,6 +294,7 @@ ID = "TailorClassTree",
 ::Const.Perks.SlingClassTree <- {
 	ID = "SlingClassTree",
 	Name = "Sling",
+	Icon = "ui/perks/perk_spec_sling.png",
 	Descriptions = [
 		"slings"
 	],
@@ -293,8 +310,9 @@ ID = "TailorClassTree",
 };
 
 ::Const.Perks.StaffClassTree <- {
-	ID = "SpecialistStaffTree",
+	ID = "StaffClassTree",
 	Name = "Staff Defense",
+	Icon = "ui/perks/perk_spec_staff.png",
 	Descriptions = [
 		"staves"
 	],
@@ -310,8 +328,9 @@ ID = "TailorClassTree",
 };
 
 ::Const.Perks.InventorClassTree <- {
-	ID = "SpecialistInventorTree",
+	ID = "InventorClassTree",
 	Name = "Inventor",
+	Icon = "ui/perks/perk_spec_firearm.png",
 	Descriptions = [
 		"firearms"
 	],
@@ -329,6 +348,7 @@ ID = "TailorClassTree",
 ::Const.Perks.NinetailsClassTree <- {
 	ID = "NinetailsClassTree",
 	Name = "Cat O' Nine Tails",
+	Icon = "ui/perks/perk_spec_cultist.png",
 	Descriptions = [
 		"ninetails"
 	],
@@ -344,8 +364,9 @@ ID = "TailorClassTree",
 }
 
 ::Const.Perks.LongswordClassTree <- {
-	ID = "SpecialistLongswordTree",
+	ID = "LongswordClassTree",
 	Name = "Swordsman",
+	Icon = "ui/perks/perk_spec_2hsword.png",
 	Descriptions = [
 		"swords"
 	],
@@ -361,8 +382,9 @@ ID = "TailorClassTree",
 };
 
 ::Const.Perks.InquisitionClassTree <- {
-	ID = "SpecialistInquisitionTree",
+	ID = "InquisitionClassTree",
 	Name = "Inquisition",
+	Icon = "ui/perks/perk_spec_xbow.png",
 	Descriptions = [
 		"crossbows"
 	],
@@ -378,8 +400,9 @@ ID = "TailorClassTree",
 };
 
 ::Const.Perks.ClubClassTree <- {
-	ID = "SpecialistBrowbeaterTree",
+	ID = "ClubClassTree",
 	Name = "Browbeater",
+	Icon = "ui/perks/perk_spec_mace.png",
 	Descriptions = [
 		"clubs"
 	],
@@ -397,6 +420,7 @@ ID = "TailorClassTree",
 ::Const.Perks.JugglerClassTree <- {
 	ID = "JugglerClassTree",
 	Name = "Juggler",
+	Icon = "ui/perks/leap_circle.png",
 	Descriptions = [
 		"acrobatics"
 	],
@@ -414,6 +438,7 @@ ID = "TailorClassTree",
 ::Const.Perks.HoundmasterClassTree <- {
 	ID = "HoundmasterClassTree",
 	Name = "Hound Master",
+	Icon = "ui/perks/perk_hound.png",
 	Descriptions = [
 		"training dogs"
 	],
@@ -431,6 +456,7 @@ ID = "TailorClassTree",
 ::Const.Perks.ScytheClassTree <- {
 	ID = "ScytheClassTree",
 	Name = "Scythe",
+	Icon = "ui/perks/perk_spec_scythe.png",
 	Descriptions = [
 		"scythes"
 	],
@@ -448,6 +474,7 @@ ID = "TailorClassTree",
 ::Const.Perks.SharpshooterClassTree <- {
 	ID = "SharpshooterClassTree",
 	Name = "Sharpshooter",
+	Icon = "ui/perks/perk_spec_longbow.png",
 	Descriptions = [
 		"longbows"
 	],
@@ -465,6 +492,7 @@ ID = "TailorClassTree",
 ::Const.Perks.RaiderClassTree <- {
 	ID = "RaiderClassTree",
 	Name = "Raider",
+	Icon = "ui/perks/perk_spec_raider.png",
 	Descriptions = [
 		"handaxes and throwing axes"
 	],
@@ -482,6 +510,7 @@ ID = "TailorClassTree",
 ::Const.Perks.SpearfisherClassTree <- {
 	ID = "SpearfisherClassTree",
 	Name = "Spearfisher",
+	Icon = "ui/perks/perk_spec_javelin.png",
 	Descriptions = [
 		"javelins"
 	],
@@ -497,6 +526,7 @@ ID = "TailorClassTree",
 };
 
 ::Const.Perks.ClassTrees <- {
+	GroupsCategory = "Class",
 	Tree = [
 		::Const.Perks.BeastClassTree,
 		::Const.Perks.FaithClassTree,

--- a/mod_legends/config/z_perks_tree_defense.nut
+++ b/mod_legends/config/z_perks_tree_defense.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.HeavyArmorTree <- {
 	ID = "HeavyArmorTree",
 	Name = "Heavy Armor",
+	Icon = "ui/perks/perk_03.png",
 	Descriptions = [
 		"heavy armor"
 	],
@@ -23,6 +24,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.MediumArmorTree <- {
 	ID = "MediumArmorTree",
 	Name = "Medium Armor",
+	Icon = "ui/perks/lithe.png",
 	Descriptions = [
 		"medium armor"
 	],
@@ -48,6 +50,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.LightArmorTree <- {
 	ID = "LightArmorTree",
 	Name = "Light Armor",
+	Icon = "ui/perks/perk_29.png",
 	Descriptions = [
 		"light armor"
 	],
@@ -72,6 +75,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ClothArmorTree <- {
 	ID = "ClothArmorTree",
 	Name = "Cloth Armor",
+	Icon = "ui/perks/himshaw.png",
 	Descriptions = [
 		"cloth armor"
 	],
@@ -111,6 +115,7 @@ if (!("Perks" in ::Const))
 //};
 
 ::Const.Perks.DefenseTrees <- {
+	GroupsCategory = "Defense",
 	Tree = [
 		//::Const.Perks.ShieldTree,
 		::Const.Perks.HeavyArmorTree,

--- a/mod_legends/config/z_perks_tree_enemy.nut
+++ b/mod_legends/config/z_perks_tree_enemy.nut
@@ -3,9 +3,13 @@ if (!("Perks" in ::Const))
 	::Const.Perks <- {};
 }
 
+local category = "Enemy";
+
 ::Const.Perks.BeastsTree <- {
 	ID = "BeastsTree",
 	Name = "Beasts",
+	Icon = "ui/perks/favoured_direwolf_01.png",
+	Category = category,
 	Descriptions = [
 		"beasts"
 	],
@@ -28,6 +32,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.GhoulTree <- {
 	ID = "GhoulTree",
 	Name = "Nachzehrers",
+	Icon = "ui/perks/favoured_ghoul_01.png",
 	Descriptions = [
 		"nachzehrers"
 	],
@@ -45,6 +50,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DirewolfTree <- {
 	ID = "DirewolfTree",
 	Name = "Direwolves",
+	Icon = "ui/perks/favoured_direwolf_01.png",
 	Descriptions = [
 		"direwolves"
 	],
@@ -62,6 +68,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SpiderTree <- {
 	ID = "SpiderTree",
 	Name = "Webknechts",
+	Icon = "ui/perks/favoured_spider_01.png",
 	Descriptions = [
 		"spiders"
 	],
@@ -79,6 +86,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.LindwurmTree <- {
 	ID = "LindwurmTree",
 	Name = "Lindwurms",
+	Icon = "ui/perks/favoured_lindwurm_01.png",
+	Category = category,
 	Descriptions = [
 		"lindwurms"
 	],
@@ -99,6 +108,8 @@ if (!("Perks" in ::Const))
 		"mystics"
 	],
 	Name = "Mystics",
+	Icon = "ui/perks/favoured_hexen_01.png",
+	Category = category,
 	Tree = [
 		[],
 		[],
@@ -116,6 +127,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SchratTree <- {
 	ID = "SchratTree",
 	Name = "Schrats",
+	Icon = "ui/perks/favoured_schrat_01.png",
 	Descriptions = [
 		"schrats"
 	],
@@ -133,6 +145,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.HexenTree <- {
 	ID = "HexenTree",
 	Name = "Hexen",
+	Icon = "ui/perks/favoured_hexen_01.png",
 	Descriptions = [
 		"hexen"
 	],
@@ -150,6 +163,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.AlpTree <- {
 	ID = "AlpTree",
 	Name = "Alps",
+	Icon = "ui/perks/favoured_alps_01.png",
 	Descriptions = [
 		"alps"
 	],
@@ -167,6 +181,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.UndeadTree <- {
 	ID = "UndeadTree",
 	Name = "Undead",
+	Icon = "ui/perks/favoured_zombie_01.png",
+	Category = category,
 	Descriptions = [
 		"undead"
 	],
@@ -187,6 +203,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SkeletonTree <- {
 	ID = "SkeletonTree",
 	Name = "Ancient Empire",
+	Icon = "ui/perks/favoured_skeleton_01.png",
 	Descriptions = [
 		"ancient empire"
 	],
@@ -204,6 +221,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ZombieTree <- {
 	ID = "ZombieTree",
 	Name = "Wiedergangers",
+	Icon = "ui/perks/favoured_zombie_01.png",
 	Descriptions = [
 		"wiedergangers"
 	],
@@ -221,6 +239,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.VampireTree <- {
 	ID = "VampireTree",
 	Name = "Necrosavants",
+	Icon = "ui/perks/favoured_vampire_01.png",
 	Descriptions = [
 		"necrosavants"
 	],
@@ -238,6 +257,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.OrcsTree <- {
 	ID = "OrcsTree",
 	Name = "Greenskins",
+	Icon = "ui/perks/favoured_ork_01.png",
+	Category = category,
 	Descriptions = [
 		"greenskins"
 	],
@@ -258,6 +279,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.OrcTree <- {
 	ID = "OrcTree",
 	Name = "Orcs",
+	Icon = "ui/perks/favoured_ork_01.png",
 	Descriptions = [
 		"orcs"
 	],
@@ -275,6 +297,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.GoblinTree <- {
 	ID = "GoblinTree",
 	Name = "Goblins",
+	Icon = "ui/perks/favoured_goblin_01.png",
 	Descriptions = [
 		"goblins"
 	],
@@ -292,6 +315,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.UnholdTree <- {
 	ID = "UnholdTree",
 	Name = "Unholds",
+	Icon = "ui/perks/favoured_unhold_01.png",
 	Descriptions = [
 		"unholds"
 	],
@@ -309,6 +333,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.CivilizationTree <- {
 	ID = "CivilizationTree",
 	Name = "Civilians",
+	Icon = "ui/perks/favoured_caravan_01.png",
+	Category = category,
 	Descriptions = [
 		"civilians"
 	],
@@ -328,6 +354,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.CaravanTree <- {
 	ID = "CaravanTree",
 	Name = "Caravans",
+	Icon = "ui/perks/favoured_caravan_01.png",
 	Descriptions = [
 		"caravans"
 	],
@@ -345,6 +372,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.MercenaryTree <- {
 	ID = "MercenaryTree",
 	Name = "Mercenaries",
+	Icon = "ui/perks/favoured_mercenary_01.png",
 	Descriptions = [
 		"mercenaries"
 	],
@@ -362,6 +390,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.NoblesTree <- {
 	ID = "NoblesTree",
 	Name = "Nobles",
+	Icon = "ui/perks/favoured_noble_01.png",
 	Descriptions = [
 		"nobles"
 	],
@@ -379,6 +408,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.OutlandersTree <- {
 	ID = "OutlandersTree",
 	Name = "Outlanders",
+	Icon = "ui/perks/favoured_bandit_01.png",
+	Category = category,
 	Descriptions = [
 		"outlanders"
 	],
@@ -399,6 +430,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BanditTree <- {
 	ID = "BanditTree",
 	Name = "Bandits",
+	Icon = "ui/perks/favoured_bandit_01.png",
 	Descriptions = [
 		"bandits"
 	],
@@ -414,8 +446,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.BarbarianTree <- {
-	ID = "BarbariansTree",
+	ID = "BarbarianTree",
 	Name = "Barbarians",
+	Icon = "ui/perks/favoured_barbarian_01.png",
 	Descriptions = [
 		"barbarians"
 	],
@@ -433,6 +466,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ArchersTree <- {
 	ID = "ArchersTree",
 	Name = "Sharpshooters",
+	Icon = "ui/perks/favoured_archer_01.png",
+	Category = category,
 	Descriptions = [
 		"sharpshooter"
 	],
@@ -449,7 +484,8 @@ if (!("Perks" in ::Const))
 
 ::Const.Perks.ArcherTree <- {
 	ID = "ArcherTree",
-	Name = "Archers"
+	Name = "Archers",
+	Icon = "ui/perks/favoured_archer_01.png",
 	Descriptions = [
 		"archers"
 	],
@@ -467,6 +503,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SwordmastersTree <- {
 	ID = "SwordmastersTree",
 	Name = "Swordmasters",
+	Icon = "ui/perks/favoured_swordmaster_01.png",
 	Descriptions = [
 		"swordmasters"
 	],
@@ -487,6 +524,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SouthernersTree <- {
 	ID = "SouthernersTree",
 	Name = "Southerners",
+	Icon = "ui/perks/favoured_southerner_01.png",
 	Descriptions = [
 		"southerners"
 	],
@@ -504,6 +542,8 @@ if (!("Perks" in ::Const))
 ::Const.Perks.NomadsTree <- {
 	ID = "NomadsTree",
 	Name = "Nomads",
+	Icon = "ui/perks/favoured_nomad_01.png",
+	Category = category,
 	Descriptions = [
 		"nomads"
 	],
@@ -519,6 +559,7 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.EnemyTrees <- {
+	GroupsCategory = "Enemy",
 	Tree = [
 		::Const.Perks.GhoulTree,
 		::Const.Perks.DirewolfTree,

--- a/mod_legends/config/z_perks_tree_enemy_armor.nut
+++ b/mod_legends/config/z_perks_tree_enemy_armor.nut
@@ -8,6 +8,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ForcefulTree <- {
 	ID = "ForcefulTree",
 	Name =  "Forceful",
+	Icon = "ui/perks/fullforce_circle.png",
 	Attributes = {
 		Hitpoints = [
 			0,

--- a/mod_legends/config/z_perks_tree_enemy_traits.nut
+++ b/mod_legends/config/z_perks_tree_enemy_traits.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ShadyTree <- {
 	ID = "ShadyTree",
 	Name =  "Shady",
+	Icon = "ui/perks/feint_circle.png",
 	Attributes = {
 		Hitpoints = [
 			0,
@@ -58,6 +59,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.AggressiveTree <- {
 	ID = "AggressiveTree",
 	Name =  "Aggressive",
+	Icon = "ui/perks/perk_27.png",
 	Attributes = {
 		Hitpoints = [
 			0,
@@ -110,6 +112,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SparringTree <- {
 	ID = "SparringTree",
 	Name =  "Sparring",
+	Icon = "ui/perks/back_to_basics_circle.png",
 	Attributes = {
 		Hitpoints = [
 			0,
@@ -162,6 +165,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.RangerTree <- {
 	ID = "RangerTree",
 	Name =  "Ranger",
+	Icon = "ui/perks/lookout_circle.png",
 	Attributes = {
 		Hitpoints = [
 			0,
@@ -216,6 +220,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.GiantTree <- {
 	ID = "GiantTree",
 	Name =  "Giant",
+	Icon = "ui/perks/perk_06.png",
 	Attributes = {
 		Hitpoints = [
 			0,

--- a/mod_legends/config/z_perks_tree_magic.nut
+++ b/mod_legends/config/z_perks_tree_magic.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BardMagicTree <- {
 	ID = "BardMagicTree",
 	Name = "Bard",
+	Icon = "ui/perks/perk_music_mastery.png",
 	Descriptions = [
 		"entertaining"
 	],
@@ -38,6 +39,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.StavesMagicTree <- {
 	ID = "StavesMagicTree",
 	Name = "Staves",
+	Icon = "ui/perks/staffmastery.png",
 	Descriptions = [
 		"staves"
 	],
@@ -55,6 +57,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ImmortalMagicTree <- {
 	ID = "ImmortalMagicTree",
 	Name = "Immortal",
+	Icon = "ui/perks/lionheart.png",
 	Descriptions = [
 		"combat"
 	],
@@ -75,6 +78,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ValaChantMagicTree <- {
 	ID = "ValaChantMagicTree",
 	Name = "Vala Chant",
+	Icon = "ui/perks/legend_vala_chanting_mastery.png",
 	Descriptions = [
 		"chants"
 	],
@@ -95,6 +99,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ValaTranceMagicTree <- {
 	ID = "ValaTranceMagicTree",
 	Name = "Vala Trance",
+	Icon = "ui/perks/legend_vala_trance_mastery.png",
 	Descriptions = [
 		"trances"
 	],
@@ -129,6 +134,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ValaSpiritMagicTree <- {
 	ID = "ValaSpiritMagicTree",
 	Name = "Vala Spirits",
+	Icon = "ui/perks/legend_vala_spiritual_bond.png",
 	Descriptions = [
 		"spirits"
 	],
@@ -146,6 +152,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.InventorMagicTree <- {
 	ID = "InventorMagicTree",
 	Name = "Inventor",
+	Icon = "ui/perks/legend_inventor_anatomy.png",
 	Descriptions = [
 		"inventor"
 	],
@@ -164,6 +171,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.RangerHuntMagicTree <- {
 	ID = "RangerHuntMagicTree",
 	Name = "Ranger",
+	Icon = "ui/perks/lookout_circle.png",
 	Descriptions = [
 		"hunting big game"
 	],
@@ -194,6 +202,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ArcherCommandTree <- {
 	ID = "ArcherCommandTree",
 	Name = "ArcherCommand",
+	Icon = "ui/perks/coordinated_volleys_circle.png",
 	Descriptions = [
 		"archer command"
 	],
@@ -219,6 +228,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.MasterArcherTree <- {
 	ID = "MasterArcherTree",
 	Name = "Deadeye",
+	Icon = "ui/perks/triplestrike56.png",
 	Descriptions = [
 		"archery"
 	],
@@ -247,7 +257,8 @@ if (!("Perks" in ::Const))
 
 ::Const.Perks.AssassinLeftoverTree <- {
 	ID = "AssassinLeftoverTree",
-	Name = "Cutthroat"
+	Name = "Cutthroat",
+	Icon = "ui/perks/perk_04.png",
 	Descriptions = [
 		"Sneaky"
 	],
@@ -278,6 +289,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BasicNecroMagicTree <- {
 	ID = "BasicNecroMagicTree",
 	Name = "Necromancy",
+	Icon = "ui/perks/raisedead2_circle.png",
 	Descriptions = [
 		"necromancy"
 	],
@@ -295,6 +307,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.WarlockMagicTree <- {
 	ID = "WarlockMagicTree",
 	Name = "Sorcery",
+	Icon = "ui/perks/siphon_circle.png",
 	Descriptions = [
 		"sorcery"
 	],
@@ -312,6 +325,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.VampireMagicTree <- {
 	ID = "VampireMagicTree",
 	Name = "Vampire",
+	Icon = "ui/perks/darkflight_circle.png",
 	Descriptions = [
 		"undeath"
 	],
@@ -329,6 +343,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ZombieMagicTree <- {
 	ID = "ZombieMagicTree",
 	Name = "Zombie",
+	Icon = "ui/perks/remake_man_circle.png",
 	Descriptions = [
 		"weidergangers"
 	],
@@ -350,6 +365,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SkeletonMagicTree <- {
 	ID = "SkeletonMagicTree",
 	Name = "Skeleton",
+	Icon = "ui/perks/rebuild_skeleton_circle.png",
 	Descriptions = [
 		"ancient undead"
 	],
@@ -370,6 +386,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BerserkerMagicTree <- {
 	ID = "BerserkerMagicTree",
 	Name = "Berserker",
+	Icon = "ui/perks/perk_35.png",
 	Descriptions = [
 		"berserking"
 	],
@@ -390,6 +407,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.CaptainMagicTree <- {
 	ID = "CaptainMagicTree",
 	Name = "Leadership",
+	Icon = "ui/perks/perk_28.png",
 	Descriptions = [
 		"leading"
 	],
@@ -409,6 +427,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.IllusionistMagicTree <- {
 	ID = "IllusionistMagicTree",
 	Name = "Illusion",
+	Icon = "ui/perks/entice_circle_56.png",
 	Descriptions = [
 		"illusion"
 	],
@@ -429,6 +448,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DivinationMagicTree <- {
 	ID = "DivinationMagicTree",
 	Name = "Divination",
+	Icon = "ui/perks/scry_perk.png",
 	Descriptions = [
 		"divination"
 	],
@@ -446,6 +466,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ConjurationMagicTree <- {
 	ID = "ConjurationMagicTree",
 	Name = "Conjuration",
+	Icon = "ui/perks/cat_circle.png",
 	Descriptions = [
 		"conjuration"
 	],
@@ -463,6 +484,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DruidMagicTree <- {
 	ID = "DruidMagicTree",
 	Name = "Druidic Arts",
+	Icon = "ui/perks/roots_circle.png",
 	Descriptions = [
 		"druidic arts"
 	],
@@ -480,6 +502,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DruidTransformTree <- {
 	ID = "DruidTransformTree",
 	Name = "Druidic transformation",
+	Icon = "ui/perks/bear2_circle.png",
 	Descriptions = [
 		"druidic transformation"
 	],
@@ -498,6 +521,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.TransmutationMagicTree <- {
 	ID = "TransmutationMagicTree",
 	Name = "Transmutation",
+	Icon = "ui/perks/potion_circle.png",
 	Descriptions = [
 		"transmutation"
 	],
@@ -515,6 +539,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.EvocationMagicTree <- {
 	ID = "EvocationMagicTree",
 	Name = "Evocation",
+	Icon = "ui/perks/storm_circle.png",
 	Descriptions = [
 		"evocation"
 	],
@@ -549,6 +574,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SeerMagicTree <- {
 	ID = "SeerMagicTree",
 	Name = "Seer",
+	Icon = "ui/perks/levitate.png",
 	Descriptions = [
 		"seer"
 	],
@@ -579,6 +605,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.AssassinMagicTree <- {
 	ID = "AssassinMagicTree",
 	Name = "Assassin",
+	Icon = "ui/perks/assassinate_circle.png",
 	Descriptions = [
 		"assassination"
 	],
@@ -596,6 +623,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.PremonitionMagicTree <- {
 	ID = "PremonitionMagicTree",
 	Name = "Premonition",
+	Icon = "ui/perks/scry_trance_circle.png",
 	Descriptions = [
 		"premonition"
 	],
@@ -613,6 +641,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.PhilosophyMagicTree <- {
 	ID = "PhilosophyMagicTree",
 	Name = "Philosophy",
+	Icon = "ui/perks/scholar_circle.png",
 	Descriptions = [
 		"philosophy"
 	],
@@ -629,6 +658,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.AlchemyMagicTree <- {
 	ID = "AlchemyMagicTree"
 	Name = "Alchemy",
+	Icon = "ui/perks/perk_34.png",
 	Descriptions = [
 		"alchemy"
 	],
@@ -645,9 +675,10 @@ if (!("Perks" in ::Const))
 	]
 }
 
-::Const.Perks.TherianthropyTree <- {
+::Const.Perks.TherianthropyMagicTree <- {
 	ID = "TherianthropyMagicTree",
 	Name = "Therianthropy",
+	Icon = "ui/perks/true_form_circle.png",
 	Descriptions = [
 		"therianthropy"
 	],
@@ -663,6 +694,7 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.MagicTrees <- {
+	GroupsCategory = "Magic",
 	Tree = [
 		::Const.Perks.ValaChantMagicTree,
 		::Const.Perks.ValaTranceMagicTree,

--- a/mod_legends/config/z_perks_tree_profession.nut
+++ b/mod_legends/config/z_perks_tree_profession.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.HealerProfessionTree <- {
 	ID = "HealerProfessionTree",
 	Name = "Healing",
+	Icon = "ui/perks/MaxMedsT2.png",
 	Descriptions = [
 		"healing"
 	],
@@ -23,6 +24,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ChefProfessionTree <- {
 	ID = "ChefProfessionTree",
 	Name = "Chef",
+	Icon = "ui/perks/meal_prep_circle.png",
 	Descriptions = [
 		"cooking"
 	],
@@ -40,6 +42,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.RepairProfessionTree <- {
 	ID = "RepairProfessionTree",
 	Name = "Repair",
+	Icon = "ui/perks/MaxToolsT1.png",
 	Descriptions = [
 		"repairs"
 	],
@@ -57,6 +60,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.BarterProfessionTree <- {
 	ID = "BarterProfessionTree",
 	Name = "Barter",
+	Icon = "ui/perks/BarterT1.png",
 	Descriptions = [
 		"bartering"
 	],
@@ -84,6 +88,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DogBreederProfessionTree <- {
 	ID = "DogBreederProfessionTree",
 	Name = "Dog Breeder",
+	Icon = "ui/perks/perk_dogs.png",
 	Descriptions = [
 		"breeding dogs"
 	],
@@ -101,6 +106,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.MinerProfessionTree <- {
 	ID = "MinerProfessionTree",
 	Name = "Mining",
+	Icon = "ui/perks/pickaxe_02.png",
 	Descriptions = [
 		"mining"
 	],
@@ -118,6 +124,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.WoodworkingProfessionTree <- {
 	ID = "WoodworkingProfessionTree",
 	Name = "Woodworking",
+	Icon = "ui/perks/woodworking.png",
 	Descriptions = [
 		"woodworking"
 	],
@@ -134,9 +141,10 @@ if (!("Perks" in ::Const))
 
 ::Const.Perks.CaravaneerProfessionTree <- {
 	ID = "CaravaneerProfessionTree",
-	Name = "Caraveneering",
+	Name = "Caravaneering",
+	Icon = "ui/perks/wheel_maintenance.png",
 	Descriptions = [
-		"woodworking"
+		"caravaneering"
 	],
 	Tree = [
 		[],
@@ -159,6 +167,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.HerbalistProfessionTree <- {
 	ID = "HerbalistProfessionTree",
 	Name = "Herbalism",
+	Icon = "ui/perks/herbs_circle.png",
 	Descriptions = [
 		"herbalism"
 	],
@@ -175,9 +184,10 @@ if (!("Perks" in ::Const))
 
 ::Const.Perks.FencingTeacherProfessionTree <- {
 	ID = "FencingTeacherProfessionTree",
-	Name = "Fencing",
+	Name = "Master Trainer",
+	Icon = "ui/perks/perk_training_01.png",
 	Descriptions = [
-		"fencing"
+		"training"
 	],
 	Tree = [
 		[],
@@ -194,6 +204,7 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.ProfessionTrees <- {
+	GroupsCategory = "Profession",
 	Tree = [
 		::Const.Perks.BarterProfessionTree,
 		::Const.Perks.CaravaneerProfessionTree,

--- a/mod_legends/config/z_perks_tree_special.nut
+++ b/mod_legends/config/z_perks_tree_special.nut
@@ -5,6 +5,7 @@ if (!("Perks" in ::Const))
 }
 
 ::Const.Perks.SpecialTrees <- {
+// GroupsCategory = "Special", // let them be categorized as "Other" for now
 Tree = [],
 Perks = [],
 

--- a/mod_legends/config/z_perks_tree_traits.nut
+++ b/mod_legends/config/z_perks_tree_traits.nut
@@ -6,6 +6,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.AgileTree <- {
 	ID = "AgileTree",
 	Name = "Agile",
+	Icon = "ui/perks/perk_23.png",
 	Descriptions = [
 		"is agile",
 		"moves gracefully",
@@ -68,6 +69,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.IndestructibleTree <- {
 	ID = "IndestructibleTree",
 	Name = "Tenacious",
+	Icon = "ui/perks/perk_30.png",
 	Descriptions = [
 		"is practicaly indestructible",
 		"is stubbornly relentless",
@@ -131,6 +133,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.MartyrTree <- {
 	ID = "MartyrTree",
 	Name = "Martyr",
+	Icon = "ui/perks/vengeance_circle.png",
 	Descriptions = [
 		"has martyr complex",
 		"strictly penatant ",
@@ -195,6 +198,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ViciousTree <- {
 	ID = "ViciousTree",
 	Name = "Vicious",
+	Icon = "ui/perks/perk_57.png",
 	Descriptions = [
 		"is vicious",
 		"seems fiendishly barbarous",
@@ -259,6 +263,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.DeviousTree <- {
 	ID = "DeviousTree",
 	Name = "Devious",
+	Icon = "ui/perks/perk_59.png",
 	Descriptions = [
 		"is devious",
 		"strikes you as shifty",
@@ -323,6 +328,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.InspirationalTree <- {
 	ID = "InspirationalTree",
 	Name = "Inspirational",
+	Icon = "ui/perks/perk_42.png",
 	Descriptions = [
 		"is inspirational",
 		"arouses loyalty in people",
@@ -387,6 +393,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.IntelligentTree <- {
 	ID = "IntelligentTree",
 	Name = "Intelligent",
+	Icon = "ui/perks/perk_21.png",
 	Descriptions = [
 		"is intelligent",
 		"is strikingly astute",
@@ -450,6 +457,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.CalmTree <- {
 	ID = "CalmTree",
 	Name = "Calm",
+	Icon = "ui/perks/clarity_circle.png",
 	Descriptions = [
 		"is calm",
 		"is soothingly relaxed",
@@ -513,6 +521,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.FastTree <- {
 	ID = "FastTree",
 	Name =  "Fast",
+	Icon = "ui/perks/unarmed_lunge.png",
 	Descriptions = [
 		"is fast",
 		"runs quickly",
@@ -575,6 +584,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.LargeTree <- {
 	ID = "LargeTree",
 	Name = "Large",
+	Icon = "ui/perks/perk_06.png",
 	Descriptions = [
 		"is large",
 		"has a hulking form",
@@ -639,6 +649,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.OrganisedTree <- {
 	ID = "OrganisedTree",
 	Name = "Organized",
+	Icon = "ui/perks/perk_20.png",
 	Descriptions = [
 		"is organized",
 		"coordinates activities effectively",
@@ -704,6 +715,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.SturdyTree <- {
 	ID = "SturdyTree",
 	Name = "Sturdy",
+	Icon = "ui/perks/steadfast_circle.png",
 	Descriptions = [
 		"is sturdy",
 		"is built to last",
@@ -766,6 +778,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.FitTree <- {
 	ID = "FitTree",
 	Name = "Fit",
+	Icon = "ui/perks/perk_54.png",
 	Descriptions = [
 		"can run all day",
 		"lifts weight for hours",
@@ -829,6 +842,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.TrainedTree <- {
 	ID = "TrainedTree",
 	Name = "Trained",
+	Icon = "ui/perks/back_to_basics_circle.png",
 	Descriptions = [
 		"is well trained",
 		"has great qualifications",
@@ -888,6 +902,7 @@ if (!("Perks" in ::Const))
 	]
 };
 ::Const.Perks.TraitsTrees <- {
+	GroupsCategory = "Traits",
 	Tree = [
 		::Const.Perks.AgileTree,
 		::Const.Perks.IndestructibleTree,

--- a/mod_legends/config/z_perks_tree_weapons.nut
+++ b/mod_legends/config/z_perks_tree_weapons.nut
@@ -4,8 +4,9 @@ if (!("Perks" in ::Const))
 }
 
 ::Const.Perks.MaceTree <- {
-	ID = "Mace",
+	ID = "MaceTree",
 	Name = "Mace",
+	Icon = "ui/perks/perk_43.png",
 	Descriptions = [
 		"maces"
 	],
@@ -56,8 +57,9 @@ if (!("Perks" in ::Const))
 
 
 ::Const.Perks.FlailTree <- {
-	ID = "Flail",
+	ID = "FlailTree",
 	Name = "Flail",
+	Icon = "ui/perks/perk_47.png",
 	Descriptions = [
 		"flails"
 	],
@@ -107,8 +109,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.HammerTree <- {
-	ID = "Hammer",
+	ID = "HammerTree",
 	Name = "Hammer",
+	Icon = "ui/perks/perk_53.png",
 	Descriptions = [
 		"hammers"
 	],
@@ -159,8 +162,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.AxeTree <- {
-	ID = "Axe",
+	ID = "AxeTree",
 	Name = "Axe",
+	Icon = "ui/perks/perk_44.png",
 	Descriptions = [
 		"axes"
 	],
@@ -210,8 +214,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.CleaverTree <- {
-	ID = "Cleaver",
+	ID = "CleaverTree",
 	Name = "Cleaver",
+	Icon = "ui/perks/perk_52.png",
 	Descriptions = [
 		"cleavers"
 	],
@@ -261,8 +266,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.TwoHandedTree <- {
-	ID = "TwoHanded",
+	ID = "TwoHandedTree",
 	Name = "Two-Handed",
+	Icon = "ui/perks/spec_greatsword.png",
 	Descriptions = [
 		"two handed weapons"
 	],
@@ -312,8 +318,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.OneHandedTree <- {
-	ID = "OneHanded",
+	ID = "OneHandedTree",
 	Name = "One-Handed",
+	Icon = "ui/perks/perk_41.png",
 	Descriptions = [
 		"one handed weapons"
 	],
@@ -363,8 +370,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.SwordTree <- {
-	ID = "Sword",
+	ID = "SwordTree",
 	Name = "Sword",
+	Icon = "ui/perks/perk_46.png",
 	Descriptions = [
 		"swords"
 	],
@@ -414,8 +422,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.DaggerTree <- {
-	ID = "Dagger",
+	ID = "DaggerTree",
 	Name = "Dagger",
+	Icon = "ui/perks/perk_51.png",
 	Descriptions = [
 		"daggers"
 	],
@@ -464,8 +473,9 @@ if (!("Perks" in ::Const))
 	]
 };
 ::Const.Perks.PolearmTree <- {
-	ID = "Polearm",
+	ID = "PolearmTree",
 	Name = "Polearm",
+	Icon = "ui/perks/perk_58.png",
 	Descriptions = [
 		"polearms"
 	],
@@ -515,8 +525,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.SpearTree <- {
-	ID = "Spear",
+	ID = "SpearTree",
 	Name = "Spear",
+	Icon = "ui/perks/perk_45.png",
 	Descriptions = [
 		"spears"
 	],
@@ -566,8 +577,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.CrossbowTree <- {
-	ID = "Crossbow",
+	ID = "CrossbowTree",
 	Name = "Crossbow",
+	Icon = "ui/perks/perk_48.png",
 	Descriptions = [
 		"crossbows"
 	],
@@ -617,8 +629,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.BowTree <- {
-	ID = "Bow",
+	ID = "BowTree",
 	Name = "Bow",
+	Icon = "ui/perks/perk_49.png",
 	Descriptions = [
 		"bows"
 	],
@@ -668,8 +681,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.ThrowingTree <- {
-	ID = "Throwing",
+	ID = "ThrowingTree",
 	Name = "Throwing",
+	Icon = "ui/perks/perk_50.png",
 	Descriptions = [
 		"throwing weapons"
 	],
@@ -719,8 +733,9 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.SlingTree <- {
-	ID = "Sling",
-	Name = "Sling"
+	ID = "SlingTree",
+	Name = "Sling",
+	Icon = "ui/perks/perk_sling_mastery.png",
 	Descriptions = [
 		"slings"
 	],
@@ -772,6 +787,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.ShieldTree <- {
 	ID = "ShieldTree",
 	Name = "Shield",
+	Icon = "ui/perks/perk_05.png",
 	Descriptions = [
 		"shields"
 	],
@@ -823,6 +839,7 @@ if (!("Perks" in ::Const))
 ::Const.Perks.FistsTree <- {
 	ID = "FistsTree",
 	Name = "Unarmed",
+	Icon = "ui/perks/unarmed_mastery_circle.png",
 	Descriptions = [
 		"unarmed combat"
 	],
@@ -881,6 +898,7 @@ if (!("Perks" in ::Const))
 };
 
 ::Const.Perks.WeaponTrees <- {
+	GroupsCategory = "Weapon",
 	Tree = [
 		::Const.Perks.FistsTree,
 		::Const.Perks.MaceTree,

--- a/mod_legends/hooks/entity/tactical/player.nut
+++ b/mod_legends/hooks/entity/tactical/player.nut
@@ -1881,7 +1881,7 @@
 		if (_killer.getSkills().hasSkill("injury.legend_aperthropy") && !this.getSkills().hasSkill("injury.legend_aperthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_aperthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained aperthropy");
 			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " is infected with aperthropy ");
 		}
@@ -1889,7 +1889,7 @@
 		if (_killer.getSkills().hasSkill("injury.legend_arborthropy") && !this.getSkills().hasSkill("injury.legend_arborthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_arborthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained arborthropy");
 			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " is infected with arborthropy ");
 		}
@@ -1897,7 +1897,7 @@
 		if (_killer.getSkills().hasSkill("injury.legend_lycanthropy") && !this.getSkills().hasSkill("injury.legend_lycanthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_lycanthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained lycanthropy");
 			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " is infected with lycanthropy ");
 		}
@@ -1905,14 +1905,14 @@
 		if (_killer.getSkills().hasSkill("injury.legend_ursathropy") && !this.getSkills().hasSkill("injury.legend_ursathropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_ursathropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained ursathropy");
 			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " is infected with ursathropy ");
 		}
 		if (_killer.getSkills().hasSkill("injury.legend_vermesthropy") && !this.getSkills().hasSkill("injury.legend_vermesthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_vermesthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained vermesthropy");
 			this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " is infected with vermesthropy ");
 		}
@@ -1932,28 +1932,28 @@
 		if (r <= 60 && !this.getSkills().hasSkill("injury.legend_lycanthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_lycanthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained lycanthropy");
 		}
 
 		if (r > 50 && r <= 80 && !this.getSkills().hasSkill("injury.legend_aperthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_aperthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained aperthropy");
 		}
 
 		if (r > 80 && r <= 95 && !this.getSkills().hasSkill("injury.legend_ursathropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_ursathropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained ursathropy");
 		}
 
 		if (r == 95 && !this.getSkills().hasSkill("injury.legend_vermesthropy"))
 		{
 			this.getSkills().add(this.new("scripts/skills/injury_permanent/legend_vermesthropy_injury"));
-			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyTree.Tree);
+			this.getBackground().addPerkGroup(this.Const.Perks.TherianthropyMagicTree.Tree);
 			this.logDebug(this.getName() + " gained vermesthropy");
 		}
 	}

--- a/mod_legends/hooks/skills/backgrounds/character_background.nut
+++ b/mod_legends/hooks/skills/backgrounds/character_background.nut
@@ -1001,6 +1001,107 @@
 		return this.Const.Perks.PerkDefObjects[_perk].ID in this.m.PerkTreeMap;
 	}
 
+	/**
+	 * Gets information on how many complete perk groups the character has,
+	 * as well as any additional perks that are not part of a complete set
+	 * 
+	 * @return A table containing the following:
+	 * 	- CompleteGroupsIDs: Table whose keys are perk group categories; values are arrays containing IDs of complete perk groups
+	 * 	- RemainingPerkDefs: Array of perkDefs (numbers representing indeces in ::Const.Perks.PerkDefObjects) that do not belong to any complete perk group
+	 */
+	o.getPerkGroups <- function ()
+	{
+		local tmp = {};
+		local nonStrayPerks = {};
+		local possibleStrayPerks = [];
+		local ret = {
+			CompleteGroupsIDs = ::Legends.Perks.buildPerkGroupCategoriesTableOfArrays(),
+			RemainingPerkDefs = [] // Array of perkDefs that do not belong to any complete perk group
+		}
+
+		foreach (perk in this.m.PerkTreeMap)
+		{
+			// 1. Find out which perk groups are possible
+			// 2. Check if each perk group is fully represented
+			// 3. List out all fully represented perk groups, and the remaining number of ungrouped perks
+			foreach (entry in perk.PerkGroups)
+			{
+				if (!(entry.ID in tmp))
+				{
+					tmp[entry.ID] <- {
+						Category = entry.Category,
+						PerkDefs = {}
+					}
+				}
+				
+				tmp[entry.ID].PerkDefs[Legends.Perk[perk.Const]] <- true;
+			}
+		}
+
+		foreach (id, entry in tmp)
+		{
+			if (::Legends.Perks.isPerkGroupFullyRepresented(id, entry.PerkDefs))
+			{
+				ret.CompleteGroupsIDs[entry.Category].push(id);
+				foreach (key, v in entry.PerkDefs)
+				{
+					if (!(key in nonStrayPerks))
+					{
+						nonStrayPerks[key] <- true;
+					}
+				}
+			}
+			else
+			{
+				foreach (key, v in entry.PerkDefs)
+				{
+					possibleStrayPerks.push(key);
+				}
+			}
+		}
+
+		foreach (perkDef in possibleStrayPerks)
+		{
+			if (!(perkDef in nonStrayPerks))
+			{
+				ret.RemainingPerkDefs.push(perkDef);
+			}
+		}
+
+		return ret;
+	}
+
+	/**
+	 * Update tooltip data to add a list of all perk groups this character has, organised by categories
+	 * 
+	 * @param arr An array of tables to hold the tooltip data, as seen in tooltip_events.nut
+	 */
+	o.extendKnownPerksTooltip <- function(arr)
+	{
+		local text = "";
+		local data = this.getPerkGroups();
+		foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
+		{
+			if (data.CompleteGroupsIDs[category].len() > 0)
+			{
+				arr.push({
+					id = 3,
+					type = "text",
+					text = "\n[u]" + category + "[/u]"
+				});
+			}
+			foreach (index, group in data.CompleteGroupsIDs[category])
+			{
+				arr.push({
+					id = 3,
+					type = "text",
+					icon = "Icon" in ::Const.Perks[group] ? ::Const.Perks[group].Icon : "ui/perks/legend_vala_days.png",
+					text = ::Const.Perks[group].Name
+				});
+			}
+		}
+	}
+
 	o.buildDescription = function( _isFinal = false )
 	{
 		if (this.isBackgroundType(this.Const.BackgroundType.Scenario))

--- a/mod_legends/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_legends/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -4058,23 +4058,21 @@
 			];
 
 		case "world-town-screen.hire-dialog-module.KnownPerks":
-			return [
+			local ret = [
 				{
 					id = 1,
 					type = "title",
-					text = "Character Perks"
+					text = "Character Perk Groups"
 				},
 				{
 					id = 2,
 					type = "description",
-					text = "[color=%negative%]Click to view perks[/color]"
-				},
-				{
-					id = 3,
-					type = "text",
-					text = entity.getBackground().getPerkTreeDescription()
+					text = "[color=%negative%]Click to view all perks[/color]"
 				}
 			];
+
+			entity.getBackground().extendKnownPerksTooltip(ret);
+			return ret;
 
 		case "world-town-screen.taxidermist-dialog-module.CraftButton":
 			return [


### PR DESCRIPTION
Show perk groups instead of listing all perks in the hiring screen known perks tooltip. Perk groups have corresponding icons, and are arranged by category.

The order of priority of perk group categories is defined in `::Legends.Perks.PerkGroupCategoriesOrder`

- New script `perk_to_perk_groups_mapping.nut` to prepare perk groups information and provide some utility functions
- New functions in `character_background.nut` to get the perk groups information of a character
- Updated several perk trees IDs to match the key
- Added icons for all perk trees
- Fixed a few typos in perk tree descriptions
- Rename `TherianthropyTree` to `TherianthropyMagicTree` for consistency