### PR TITLE
Dual column tooltip text (used for perk groups)

### DIFF
--- a/mod_legends/hooks/skills/backgrounds/character_background.nut
+++ b/mod_legends/hooks/skills/backgrounds/character_background.nut
@@ -1078,23 +1078,31 @@
 	 */
 	o.extendKnownPerksTooltip <- function(arr)
 	{
-		local text = "";
 		local data = this.getPerkGroups();
+		local last = arr[arr.len() - 1];
+		local iter = "id" in last ? last.id : 3;
 		foreach (category in ::Legends.Perks.PerkGroupCategoriesOrder)
 		{
+			iter++;
 			if (data.CompleteGroupsIDs[category].len() > 0)
 			{
 				arr.push({
-					id = 3,
+					id = iter,
 					type = "text",
 					text = "\n[u]" + category + "[/u]"
 				});
 			}
+
+			local counter = 0;
+
 			foreach (index, group in data.CompleteGroupsIDs[category])
 			{
+				counter++;
 				arr.push({
-					id = 3,
-					type = "text",
+					id = iter,
+					type = "textDualColumn",
+					listCount = counter,
+					listLength = data.CompleteGroupsIDs[category].len(),
 					icon = "Icon" in ::Const.Perks[group] ? ::Const.Perks[group].Icon : "ui/perks/legend_vala_days.png",
 					text = ::Const.Perks[group].Name
 				});

--- a/ui/screens/tooltip/modules/tooltip_module.css
+++ b/ui/screens/tooltip/modules/tooltip_module.css
@@ -569,3 +569,46 @@
 	margin-left: 3rem;
 }
 
+/*Dual Column*/
+.tooltip-module .content-dual-column-container
+{
+	display: flex;
+	width: 100%;
+	/*border: 2px solid rgb(255, 0, 0);*/
+}
+
+.tooltip-module .content-dual-column-container-child
+{
+  display: flex;
+  flex: 1;                /* Each child takes equal space */
+  flex-direction: column;
+  /*border: 2px solid rgb(0,255,0);*/
+}
+
+.tooltip-module .dual-column-row
+{
+	display: flex;
+	width: 100%;
+	flex-direction: row;
+}
+
+.tooltip-module .dual-column-row-label-section
+{
+	width: 3rem;
+}
+
+.tooltip-module .dual-column-row-text-section
+{
+	flex: 1;
+}
+
+.tooltip-module .dual-column-row-label-section .label
+{
+	line-height: 2.0rem;
+}
+
+.tooltip-module .dual-column-row-text-section .text
+{
+	line-height: 2.0rem;
+	text-align: left;
+}

--- a/ui/screens/tooltip/modules/tooltip_module.js
+++ b/ui/screens/tooltip/modules/tooltip_module.js
@@ -975,6 +975,11 @@ TooltipModule.prototype.buildFromData = function(_data, _shouldBeUpdated, _conte
 	var headerLastText    = null;
 	var atmosphericImageContainer = null;
 
+	var dualColumnGroupID = null;
+	var dualColumnContainer = null;
+	var dualColumnContainerLeft = null;
+	var dualColumnContainerRight = null;
+
 	// fill container
 	for (var i = 0; i < _data.length; ++i)
 	{
@@ -1091,6 +1096,66 @@ TooltipModule.prototype.buildFromData = function(_data, _shouldBeUpdated, _conte
 				else
 				{
 					element = this.updateContentTextDiv(rightContentContainer, data);
+				}
+
+				if (element !== null)
+				{
+					hasContent = true;
+				}
+			} break;
+
+			// Display text across 2 columns
+			// Content intended to be spread across the 2 columns must be grouped together and share the same `data.id` value, and have different `data.listCount` values
+			// For example, the data entries {id: 1, listCount: 1}, {id: 1, listCount: 2} form a group,
+			// whereas the data entries {id: 2, listCount: 1}, {id: 2, listCount 2} form a separate group
+			// The input array of data MUST be in the order [{id: 1, listCount: 1}, {id: 1, listCount: 2}, {id: 2, listCount: 1}, {id: 2, listCount 2}]
+			case 'textDualColumn':
+			{
+				if (!("listCount" in data))
+				{
+					console.error("Missing 'listCount' in data for textDualColumn tooltip");
+					break;
+				}
+
+				if (!("listLength" in data))
+				{
+					console.error("Missing 'listLength' in data for textDualColumn tooltip");
+					break;
+				}
+
+				var element = null;
+				// console.error("[textDualColumn] id: " + data.id + " | listCount: " + data.listCount + " | listLength: " + data.listLength + " | text: " + data.text);
+
+				if (!shouldBeUpdated)
+				{
+					if (data.id !== dualColumnGroupID)
+					{
+						// Create new dualColumnContainer
+						dualColumnGroupID = data.id;
+						dualColumnContainer = $('<div class="row content-dual-column-container"></div>');
+						dualColumnContainer.attr('id', 'tooltip-module-content-text-dual-column-container-' + data.id);
+
+						rightContentContainer.append(dualColumnContainer);
+
+						dualColumnContainerLeft = $('<div class="row content-dual-column-container-child"></div>');
+						dualColumnContainerRight = $('<div class="row content-dual-column-container-child"></div>');
+
+						dualColumnContainer.append(dualColumnContainerLeft, dualColumnContainerRight);
+					}
+					
+					// Add data from left to right (as opposed to top to bottom in the left column first)
+					if (data.listCount % 2 === 1)
+					{
+						element = this.addContentDualColumnTextDiv(dualColumnContainerLeft, data);
+					}
+					else
+					{
+						element = this.addContentDualColumnTextDiv(dualColumnContainerRight, data);
+					}
+				}
+				else
+				{
+					element = this.updateContentDualColumnTextDiv(rightContentContainer, data);
 				}
 
 				if (element !== null)
@@ -1862,6 +1927,152 @@ TooltipModule.prototype.updateContentTextDiv = function(_parentDIV, _data, _isCh
 	}
 };
 
+/**
+ * Similar to addContentTextDiv, but uses different CSS configurations.
+ * Meant to be called when adding text to dual columns (i.e. when _data.type === 'textDualColumn')
+ * 
+ * @param {jQuery} _parentDIV The parent div to append the content created
+ * @param {Object} _data The data content
+ * @returns {jQuery} A container containing the populated data
+ */
+TooltipModule.prototype.addContentDualColumnTextDiv = function(_parentDIV, _data)
+{
+	if (!('text' in _data) || typeof(_data.text) !== 'string' || _data.text.length === 0)
+	{
+		return null;
+	}
+
+	var container = null;
+	container = $('<div class="dual-column-row"></div>');
+	container.attr('id', 'tooltip-module-content-dual-column-row-' + _data.id + '-' + _data.listCount);
+
+	_parentDIV.append(container);
+
+	var hasIcon = ('icon' in _data);
+	var hasLabel = ('label' in _data);
+	var labelSection = null;
+
+	if (hasIcon || hasLabel)
+	{
+		labelSection = $('<div class="dual-column-row-label-section"></div>');
+		container.append(labelSection);
+
+		var label = $('<div class="label text-font-small font-color-ink"></div>');
+		label.attr('id', 'tooltip-module-content-dual-column-label-' + _data.id + '-' + _data.listCount);
+		labelSection.append(label);
+
+		// prefer icon over label
+		if (hasIcon)
+		{
+			var image = $('<img/>');
+			image.attr('src', Path.GFX + _data.icon);
+			label.append(image);
+		}
+		else if (hasLabel)
+		{
+			if (typeof(_data.label) == 'string')
+			{
+				var parsedLabel = XBBCODE.process({
+					text: _data.label,
+					removeMisalignedTags: false,
+					addInLineBreaks: true
+				});
+			
+				label.html(parsedLabel.html);
+			}
+		}
+	}
+
+	// add text
+	var textSection = $('<div class="dual-column-row-text-section"></div>');
+	container.append(textSection);
+
+	var text = $('<div class="text text-font-small font-color-ink"></div>');
+	text.attr('id', 'tooltip-module-content-dual-column-text-' + _data.id + '-' + _data.listCount);
+	textSection.append(text);
+
+	if (typeof(_data.text) == 'string')
+	{
+		var parsedText = XBBCODE.process({
+			text: _data.text,
+			removeMisalignedTags: false,
+			addInLineBreaks: true
+		});
+	
+		text.html(parsedText.html);
+	}
+
+	// add children rows (untested lol)
+	if ('children' in _data)
+	{
+		for (var i = 0; i < _data.children.length; ++i)
+		{
+			this.addContentDualColumnTextDiv(container, _data.children[i]);
+		}
+	}
+
+	return container;
+};
+
+/**
+ * Similar to updateContentTextDiv, but uses different CSS configurations.
+ * Meant to be called when adding text to dual columns (i.e. when _data.type === 'textDualColumn')
+ * 
+ * @param {jQuery} _parentDIV The parent div containing the content to be updated
+ * @param {Object} _data The data content
+ * @returns {jQuery} A container containing the populated data
+ */
+TooltipModule.prototype.updateContentDualColumnTextDiv = function(_parentDIV, _data)
+{
+	var container = _parentDIV.find('#tooltip-module-content-dual-column-row-' + _data.id + '-' + _data.listCount + ':first');
+
+	
+	var flags = this.extractDataFlags(_data);
+	if (this.flagsContain(flags, 'remove'))
+	{
+		if (container.length > 0)
+		{
+			container.remove();
+		}
+		return null;
+	}
+	else
+	{
+		if (container.length === 0)
+		{
+			return this.addContentDualColumnTextDiv(_parentDIV, _data);
+		}
+
+		// TODO: update label - if needed by the game
+
+		// update text
+		if ('text' in _data)
+		{
+			var text = container.find('#tooltip-module-content-dual-column-text-' + _data.id + '-' + _data.listCount + ':first');
+
+			if (text.length === 0)
+			{
+				console.error('ERROR: Failed to find "tooltip-module-content-dual-column-text-' + _data.id + '-' + _data.listCount + '" element while interpreting tooltip data.');
+				return null;
+			}
+
+			if (typeof(_data.text) == 'string')
+			{
+				var parsedText = XBBCODE.process({
+					text: _data.text,
+					removeMisalignedTags: false,
+					addInLineBreaks: true
+				});
+			
+				text.html(parsedText.html);
+			}
+		}
+
+		// TODO: update children - if needed by the game
+
+		return container;
+	}
+};
 
 TooltipModule.prototype.addContentProgressbarDiv = function(_parentDIV, _data)
 {


### PR DESCRIPTION
A new `"textDualColumn"` type of tooltip text entry, which allows content to be spread across 2 columns.

This is used in the recently introduced perk groups tooltip in the Known Perks tooltip in the hiring screen.

To use dual column texts in tooltips, the tooltip data must be arranged as follows:
- `type = "textDualColumn"`
- The tooltip data entries that are to be spread across the columns must be grouped together (i.e. consecutive) in the array containing the tooltip data
- Data entries will be grouped together according to their `id` value

For example, the tooltip data array in Squirrel might looking something like this:
```JS
[
{type="textDualColumn", id=1, listCount=1, text="foo1"},
{type="textDualColumn", id=1, listCount=2, text="bar1"},
{type="textDualColumn", id=1, listCount=3, text="baz1"},
{type="textDualColumn", id=2, listCount=1, text="foo2"},
{type="textDualColumn", id=2, listCount=2, text="bar2"}
]
```
(NOTE: entries with the same `id` value MUST come consecutively in the array, as shown above)

The tooltip will display the text as follows:
|     |     |
|-----|-----|
| foo1 | bar1 |
| baz1 |      |
| foo2 | bar2 |

In-game BEFORE (using `type = "text"`)
![365360_50](https://github.com/user-attachments/assets/1b4ed398-6151-45ca-a6e7-2b8070a06890)

In-game AFTER (using `type = "textDualColumn"` and following the pattern outlined above)
![365360_60](https://github.com/user-attachments/assets/14cea536-2bf7-45c2-9112-f75ed22372ff)