### PR TITLE
Update legend_silver_ingot_01_blueprint.nut

### DIFF
--- a/scripts/crafting/blueprints/trade/legend_silver_ingot_01_blueprint.nut
+++ b/scripts/crafting/blueprints/trade/legend_silver_ingot_01_blueprint.nut
@@ -17,7 +17,7 @@ this.legend_silver_ingot_01_blueprint <- this.inherit("scripts/crafting/blueprin
 		local skills = [
 			{
 				Scripts = [
-					"scripts/skills/perks/perk_legend_tools_spares"
+					"scripts/skills/backgrounds/legend_blacksmith_background"
 				]
 			}
 		];
@@ -30,4 +30,5 @@ this.legend_silver_ingot_01_blueprint <- this.inherit("scripts/crafting/blueprin
 	}
 
 });
+
 


### PR DESCRIPTION
Requiring a Blacksmith instead of the Spare Parts perk, meaning a Tailor (or other bgs with repair tree) can't craft ingots anymore