### PR TITLE
pacifist_tooltip_adjustment

### DIFF
--- a/mod_legends/!!config/perk_strings.nut
+++ b/mod_legends/!!config/perk_strings.nut
@@ -2714,12 +2714,12 @@ Perfect the art of casting nets.
 ";
 
 ::Const.Strings.PerkDescription.LegendPacifist <- @"
-Fighting is a brutal thuggish pastime, most folk prefer a life without frequent bouts of extreme violence.
+Not every lesson learned in battle has to be applied to the lethal side of the trade. After all, most folk prefer a life without frequent bouts of extreme violence.
 
 [color=%passive%][u]Passive:[/u][/color]
 • Grants [color=%positive%]+10%[/color] Resolve.
 
-• This character now gains experience from battle while in reserves.
+• Now passively gains experience from battle while in reserves. Does not draw from fighters XP-pool.
 
 • Additionally, this character does not count towards your party strength when determining game difficulty.
 


### PR DESCRIPTION
(First time im using GitHub; pls dont be to hard on me. Im not a hundred percent sure what im doing here.)
Feel free to reject:

Changes the tooltip of the pacifist-perk to reflect better that pacifists do not steal combatants xp.
At least in my case I was waiting until my core-bros where high level when I could have spammed pacifists day one.
Well, perhaps it's better noone knows. Your call, really.

If the writing is inadequate id be happy to revise it. (Writing on point is hard.)

Happy modding!