### PR TITLE
Rotten flesh tooltip fix

### DIFF
--- a/mod_legends/!!config/perk_strings.nut
+++ b/mod_legends/!!config/perk_strings.nut
@@ -2714,12 +2714,12 @@ Perfect the art of casting nets.
 ";
 
 ::Const.Strings.PerkDescription.LegendPacifist <- @"
-Fighting is a brutal thuggish pastime, most folk prefer a life without frequent bouts of extreme violence.
+Not every lesson learned from battle has to be applied to the lethal side of the trade. After all, most folk prefer a life without frequent bouts of extreme violence.
 
 [color=%passive%][u]Passive:[/u][/color]
 • Grants [color=%positive%]+10%[/color] Resolve.
 
-• This character now gains experience from battle while in reserves.
+• Now passively gains experience from battle while in reserves. Does not draw from fighters XP-pool.
 
 • Additionally, this character does not count towards your party strength when determining game difficulty.
 

--- a/mod_legends/!!config/perk_strings.nut
+++ b/mod_legends/!!config/perk_strings.nut
@@ -2714,12 +2714,12 @@ Perfect the art of casting nets.
 ";
 
 ::Const.Strings.PerkDescription.LegendPacifist <- @"
-Not every lesson learned from battle has to be applied to the lethal side of the trade. After all, most folk prefer a life without frequent bouts of extreme violence.
+Fighting is a brutal thuggish pastime, most folk prefer a life without frequent bouts of extreme violence.
 
 [color=%passive%][u]Passive:[/u][/color]
 • Grants [color=%positive%]+10%[/color] Resolve.
 
-• Now passively gains experience from battle while in reserves. Does not draw from fighters XP-pool.
+• This character now gains experience from battle while in reserves.
 
 • Additionally, this character does not count towards your party strength when determining game difficulty.
 

--- a/scripts/skills/traits/legend_rotten_flesh_trait.nut
+++ b/scripts/skills/traits/legend_rotten_flesh_trait.nut
@@ -27,7 +27,7 @@ this.legend_rotten_flesh_trait <- this.inherit("scripts/skills/traits/character_
 				id = 7,
 				type = "text",
 				icon = "ui/icons/days_wounded.png",
-				text = "-3 Action Points. Recovers hitpoints at only 10% of the normal rate. Requires 3 provisions a day."
+				text = "Movement costs +1 Action Points per tile. Recovers hitpoints at only 10% of the normal rate. Requires 3 provisions a day."
 			},
 			{
 				id = 7,


### PR DESCRIPTION
the zombo-update a few patches ago did not include this tooltip.
everything else is fine I believe.
(and hopefully no gitHub-shenanigans again. I checked + I guess I would see in the commits below.)