### PR TITLE
Summon fix attempt1

### DIFF
--- a/mod_legends/hooks/entity/tactical/actor.nut
+++ b/mod_legends/hooks/entity/tactical/actor.nut
@@ -21,7 +21,7 @@
 	local isPlayerControlled = o.isPlayerControlled;
 	o.isPlayerControlled = function() {
 		if (this.getFaction() == this.Const.Faction.PlayerAnimals && this.m.IsControlledByPlayer) return true;
-		isPlayerControlled();
+		return isPlayerControlled();
 	};
 	
 	local setCurrentMovementType = o.setCurrentMovementType;

--- a/mod_legends/hooks/entity/tactical/actor.nut
+++ b/mod_legends/hooks/entity/tactical/actor.nut
@@ -19,10 +19,11 @@
 	}
 
 	local isPlayerControlled = o.isPlayerControlled;
-	o.isPlayerControlled = function() {
-		if (this.getFaction() == this.Const.Faction.PlayerAnimals && this.m.IsControlledByPlayer) return true;
+	o.isPlayerControlled  = {function isPlayerControlled(){	
+		if ((this.getFaction() == this.Const.Faction.PlayerAnimals) && this.m.IsControlledByPlayer) return true;
 		return isPlayerControlled();
-	};
+		
+	}}.isPlayerControlled;
 	
 	local setCurrentMovementType = o.setCurrentMovementType;
 	o.setCurrentMovementType = function( _t ) // to trigger the removal of stances skill upon being moved out of will

--- a/mod_legends/hooks/entity/tactical/actor.nut
+++ b/mod_legends/hooks/entity/tactical/actor.nut
@@ -18,6 +18,12 @@
 		return -1;
 	}
 
+	local isPlayerControlled = o.isPlayerControlled;
+	o.isPlayerControlled = function() {
+		if (this.getFaction() == this.Const.Faction.PlayerAnimals && this.m.IsControlledByPlayer) return true;
+		isPlayerControlled();
+	};
+	
 	local setCurrentMovementType = o.setCurrentMovementType;
 	o.setCurrentMovementType = function( _t ) // to trigger the removal of stances skill upon being moved out of will
 	{

--- a/scripts/entity/tactical/legend_zombie.nut
+++ b/scripts/entity/tactical/legend_zombie.nut
@@ -179,7 +179,7 @@ this.legend_zombie <- this.inherit("scripts/entity/tactical/enemies/zombie", {
 		local XPgroup = _actor.getXPValue() * (1.0 - this.Const.XP.XPForKillerPct);
 
 		local summoner = getFlags().get("Summoner");
-		if (summoner != null && "addXP" in summoner)
+		if (summoner != null && ::MSU.isKindOf(summoner, "player"))
 		{
 			summoner.addXP(this.Math.floor(XPkiller * 0.50));
 		}

--- a/scripts/entity/tactical/legend_zombie.nut
+++ b/scripts/entity/tactical/legend_zombie.nut
@@ -185,13 +185,7 @@ this.legend_zombie <- this.inherit("scripts/entity/tactical/enemies/zombie", {
 		}
 
 		local brothers = this.Tactical.Entities.getInstancesOfFaction(this.Const.Faction.Player);
-		local summonedCount = 0;
-		
-		foreach( bro in brothers )
-		{
-			if (bro.getFlags().has("IsSummoned")) summonedCount += 1;	//"Summon the Elector Counts!"
-		}
-		
+				
 		if (brothers.len() == 1)
 		{
 			this.addXP(XPgroup);
@@ -200,7 +194,7 @@ this.legend_zombie <- this.inherit("scripts/entity/tactical/enemies/zombie", {
 		{
 			foreach( bro in brothers )
 			{
-				bro.addXP(this.Math.max(1, this.Math.floor(XPgroup * 1.0 / (brothers.len() - summonedCount))));
+				bro.addXP(this.Math.max(1, this.Math.floor(XPgroup / brothers.len())));
 			}
 		}
 	}

--- a/scripts/skills/actives/legend_spawn_skill.nut
+++ b/scripts/skills/actives/legend_spawn_skill.nut
@@ -215,12 +215,9 @@ this.legend_spawn_skill <- this.inherit("scripts/skills/skill", {
 		}
 
 		local entity = this.Tactical.spawnEntity(this.getScript(), _targetTile.Coords.X, _targetTile.Coords.Y);
-		if (this.m.IsControlledByPlayer)
-		{
-			entity.setFaction(this.Const.Faction.Player);
-		} else {
-			entity.setFaction(this.Const.Faction.PlayerAnimals);
-		}
+		entity.setFaction(this.Const.Faction.PlayerAnimals);
+		if (this.m.IsControlledByPlayer) entity.m.IsControlledByPlayer = true;	//might not be necessary, skellos and zombos are spawned with true anyways
+		
 		entity.setItem(spawnItem);
 		entity.setName(spawnItem.getName());
 		entity.assignRandomEquipment();


### PR DESCRIPTION
I hope the commits are somewhat self-explanatory.
-summons summoned by legend_summon_skill now belong to faction PlayerAnimals. (so they do not count to brothers for e.g. sharing GroupXP)
-Wrap to actor.nut's "isPlayerControlled()" so it additionally checks for these new playercontrolled summons that belong to the faction PlayerAnimals.
-revert former fix
Additional:
-fix to summoner not gaining share of killerXP

changes tested once; scanned for whether playercontrolled PlayerAnimals could cause problems, but all mentions of the faction PlayerAnimals and all mentions of actor.m.IsControlledByPlayer should work fine for both vanilla and legends.